### PR TITLE
feat(frontend): gate community pulse behind waffle flag

### DIFF
--- a/services/django/README.md
+++ b/services/django/README.md
@@ -90,3 +90,31 @@ The `AdminOnlyMiddleware` restricts access to the admin interface. Users can acc
    - `ml_ops` - ML Operations team members
    - `infrastructure` - Infrastructure team members
    - `engineering` - Engineering team members
+
+## Stakeholder-Controlled Toggles
+
+One useful pattern is giving non-technical teammates access to a very small part of the system so they can safely flip functionality on or off without needing code changes or a full deploy.
+
+In this repo, `product` and `ml_ops` group members can manage the `ActiveMLModel` admin screen, which writes to the `active_ml_models` table. That makes the Django admin a lightweight control panel for turning specific model-backed behavior on or off.
+
+This is a good fit for:
+
+- Enabling or disabling a specific ML model version
+- Giving product or ML stakeholders a safe way to test rollout decisions
+- Letting internal teams control operational switches without broader admin ownership
+
+The same general approach also works for other "flip the bit" surfaces such as feature flags, runtime config, or model-backed booleans:
+
+1. Store the toggle in the database
+2. Register the model in Django admin
+3. Restrict access with group-based admin permissions
+4. Seed or assign the relevant Django groups for the stakeholders who should control it
+
+### Example Test Users
+
+Migration [`0022_seed_ml_model_admin_test_users.py`](./core/migrations/0022_seed_ml_model_admin_test_users.py) creates two example stakeholder accounts you can use locally:
+
+- `product-test@lotus.dev` in the `product` group
+- `mlops-test@lotus.dev` in the `ml_ops` group
+
+Both use the password `testpass123`.

--- a/services/django/core/admin.py
+++ b/services/django/core/admin.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.contrib import admin
 from django.contrib.auth.admin import (
     GroupAdmin as BaseGroupAdmin,
@@ -43,6 +44,8 @@ class LotusAdminSite(UnfoldAdminSite):
 # Create custom admin site instance
 admin_site = LotusAdminSite(name="lotus_admin")
 
+ACTIVE_ML_MODEL_ALLOWED_GROUPS = ("product", "ml_ops")
+
 
 @admin.register(RuntimeConfig, site=admin_site)
 class RuntimeConfigAdmin(ModelAdmin):
@@ -69,12 +72,18 @@ class RuntimeConfigAdmin(ModelAdmin):
 def has_ml_model_permission(user):
     """
     Check if user has permission to manage ML models.
-    Allows users with Admin role or users in allowed groups.
-    Uses the same logic as middleware for consistency.
+    Allows users with the Admin role or members of the product/ml_ops groups.
     """
-    from .middleware import _has_admin_access
+    if not user.is_authenticated:
+        return False
 
-    return _has_admin_access(user)
+    has_admin_role = LotusUser.objects.filter(
+        email=user.email,
+        role=getattr(settings, "ADMIN_ROLE_NAME", "Admin"),
+    ).exists()
+    is_in_allowed_group = user.groups.filter(name__in=ACTIVE_ML_MODEL_ALLOWED_GROUPS).exists()
+
+    return has_admin_role or is_in_allowed_group
 
 
 @admin.register(ActiveMLModel, site=admin_site)
@@ -90,19 +99,23 @@ class ActiveMLModelAdmin(ModelAdmin):
     list_editable = ("is_enabled",)  # Allow quick editing of enabled status from list view
 
     def has_add_permission(self, request):
-        """Only allow Admin role or allowed groups (product, ml_ops, infrastructure, engineering) to add."""
+        """Only allow Admin role or product/ml_ops groups to add."""
         return has_ml_model_permission(request.user)
 
     def has_change_permission(self, request, obj=None):
-        """Only allow Admin role or allowed groups (product, ml_ops, infrastructure, engineering) to change."""
+        """Only allow Admin role or product/ml_ops groups to change."""
         return has_ml_model_permission(request.user)
 
     def has_delete_permission(self, request, obj=None):
-        """Only allow Admin role or allowed groups (product, ml_ops, infrastructure, engineering) to delete."""
+        """Only allow Admin role or product/ml_ops groups to delete."""
         return has_ml_model_permission(request.user)
 
     def has_view_permission(self, request, obj=None):
-        """Only allow Admin role or allowed groups (product, ml_ops, infrastructure, engineering) to view."""
+        """Only allow Admin role or product/ml_ops groups to view."""
+        return has_ml_model_permission(request.user)
+
+    def has_module_permission(self, request):
+        """Keep the model visible on the admin index for allowed users."""
         return has_ml_model_permission(request.user)
 
 

--- a/services/django/core/auth_utils.py
+++ b/services/django/core/auth_utils.py
@@ -1,0 +1,24 @@
+from django.conf import settings
+
+
+def has_admin_role(lotus_user):
+    """Return whether the Lotus user should be treated as an admin."""
+    return bool(lotus_user and lotus_user.role == getattr(settings, "ADMIN_ROLE_NAME", "Admin"))
+
+
+def is_in_allowed_admin_group(django_user):
+    """Return whether the Django user belongs to an admin-enabled stakeholder group."""
+    allowed_groups = getattr(settings, "ADMIN_ALLOWED_GROUPS", ["product_manager"])
+    return django_user.groups.filter(name__in=allowed_groups).exists()
+
+
+def desired_django_access_flags(*, django_user, lotus_user):
+    """
+    Compute the Django auth flags implied by Lotus role and stakeholder groups.
+
+    `is_superuser` stays reserved for the Lotus admin role.
+    `is_staff` can also be granted through the configured admin-allowed groups.
+    """
+    is_superuser = has_admin_role(lotus_user)
+    is_staff = is_superuser or is_in_allowed_admin_group(django_user)
+    return is_staff, is_superuser

--- a/services/django/core/management/commands/sync_django_users.py
+++ b/services/django/core/management/commands/sync_django_users.py
@@ -1,6 +1,7 @@
 from django.contrib.auth.models import User as DjangoUser
 from django.core.management.base import BaseCommand
 
+from core.auth_utils import desired_django_access_flags
 from core.models import User as LotusUser
 
 
@@ -25,9 +26,7 @@ class Command(BaseCommand):
         skipped_count = 0
 
         for lotus_user in lotus_users:
-            django_user_exists = DjangoUser.objects.filter(
-                username=lotus_user.email
-            ).exists()
+            django_user_exists = DjangoUser.objects.filter(username=lotus_user.email).exists()
 
             if django_user_exists:
                 django_user = DjangoUser.objects.get(username=lotus_user.email)
@@ -39,16 +38,18 @@ class Command(BaseCommand):
                     if not dry_run:
                         django_user.email = lotus_user.email
 
-                # Check if admin privileges need updating
-                is_admin = lotus_user.role == "Admin"
+                desired_is_staff, desired_is_superuser = desired_django_access_flags(
+                    django_user=django_user,
+                    lotus_user=lotus_user,
+                )
                 if (
-                    django_user.is_staff != is_admin
-                    or django_user.is_superuser != is_admin
+                    django_user.is_staff != desired_is_staff
+                    or django_user.is_superuser != desired_is_superuser
                 ):
                     needs_update = True
                     if not dry_run:
-                        django_user.is_staff = is_admin
-                        django_user.is_superuser = is_admin
+                        django_user.is_staff = desired_is_staff
+                        django_user.is_superuser = desired_is_superuser
 
                 if needs_update:
                     if not dry_run:
@@ -57,21 +58,20 @@ class Command(BaseCommand):
                     self.stdout.write(
                         self.style.SUCCESS(
                             f"  ✓ Updated Django User for {lotus_user.email} "
-                            f"(role: {lotus_user.role}, is_staff: {is_admin})"
+                            f"(role: {lotus_user.role}, is_staff: {desired_is_staff})"
                         )
                     )
                 else:
                     skipped_count += 1
-                    self.stdout.write(
-                        f"  - Skipped {lotus_user.email} (already in sync)"
-                    )
+                    self.stdout.write(f"  - Skipped {lotus_user.email} (already in sync)")
             else:
                 if not dry_run:
+                    is_admin = lotus_user.role == "Admin"
                     django_user = DjangoUser.objects.create(
                         username=lotus_user.email,
                         email=lotus_user.email,
-                        is_staff=(lotus_user.role == "Admin"),
-                        is_superuser=(lotus_user.role == "Admin"),
+                        is_staff=is_admin,
+                        is_superuser=is_admin,
                     )
                 created_count += 1
                 self.stdout.write(

--- a/services/django/core/migrations/0021_seed_community_pulse_flag.py
+++ b/services/django/core/migrations/0021_seed_community_pulse_flag.py
@@ -1,0 +1,45 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("core", "0020_user_community_country_code_and_more"),
+        ("waffle", "0004_update_everyone_nullbooleanfield"),
+    ]
+
+    operations = [
+        migrations.RunSQL(
+            sql="""
+                INSERT INTO source.waffle_flag (
+                    name,
+                    everyone,
+                    testing,
+                    superusers,
+                    staff,
+                    authenticated,
+                    languages,
+                    rollout,
+                    note,
+                    created,
+                    modified
+                )
+                VALUES (
+                    'community_pulse',
+                    false,
+                    false,
+                    false,
+                    false,
+                    false,
+                    '',
+                    false,
+                    'Show Community Pulse surfaces in the frontend',
+                    now(),
+                    now()
+                )
+                ON CONFLICT (name) DO NOTHING;
+            """,
+            reverse_sql="""
+                DELETE FROM source.waffle_flag WHERE name = 'community_pulse';
+            """,
+        ),
+    ]

--- a/services/django/core/migrations/0022_seed_ml_model_admin_test_users.py
+++ b/services/django/core/migrations/0022_seed_ml_model_admin_test_users.py
@@ -1,0 +1,101 @@
+import uuid
+
+from django.contrib.auth.hashers import make_password
+from django.db import migrations
+
+TEST_PASSWORD = "testpass123"
+SEEDED_USERS = (
+    {
+        "email": "product-test@lotus.dev",
+        "username": "product-test@lotus.dev",
+        "first_name": "Product",
+        "last_name": "Tester",
+        "group": "product",
+        "role": "Consumer",
+        "timezone": "America/Los_Angeles",
+        "community_insights_opt_in": True,
+        "community_location_opt_in": True,
+        "community_country_code": "US",
+        "community_region_code": "US-CA",
+    },
+    {
+        "email": "mlops-test@lotus.dev",
+        "username": "mlops-test@lotus.dev",
+        "first_name": "ML",
+        "last_name": "Ops",
+        "group": "ml_ops",
+        "role": "Consumer",
+        "timezone": "UTC",
+        "community_insights_opt_in": False,
+        "community_location_opt_in": False,
+        "community_country_code": None,
+        "community_region_code": None,
+    },
+)
+
+
+def seed_ml_model_admin_test_users(apps, schema_editor):
+    Group = apps.get_model("auth", "Group")
+    DjangoUser = apps.get_model("auth", "User")
+    LotusUser = apps.get_model("core", "User")
+
+    for user_data in SEEDED_USERS:
+        group = Group.objects.get(name=user_data["group"])
+
+        lotus_user, _ = LotusUser.objects.update_or_create(
+            email=user_data["email"],
+            defaults={
+                "id": uuid.uuid5(uuid.NAMESPACE_DNS, f"lotus:{user_data['email']}"),
+                "password": None,
+                "salt": None,
+                "oauth_provider": None,
+                "role": user_data["role"],
+                "timezone": user_data["timezone"],
+                "community_insights_opt_in": user_data["community_insights_opt_in"],
+                "community_location_opt_in": user_data["community_location_opt_in"],
+                "community_country_code": user_data["community_country_code"],
+                "community_region_code": user_data["community_region_code"],
+            },
+        )
+
+        django_user, _ = DjangoUser.objects.update_or_create(
+            username=user_data["username"],
+            defaults={
+                "email": user_data["email"],
+                "first_name": user_data["first_name"],
+                "last_name": user_data["last_name"],
+                "is_staff": True,
+                "is_superuser": False,
+                "is_active": True,
+                "password": make_password(TEST_PASSWORD),
+            },
+        )
+
+        django_user.groups.add(group)
+
+        if django_user.email != lotus_user.email:
+            django_user.email = lotus_user.email
+            django_user.save(update_fields=["email"])
+
+
+def reverse_seed_ml_model_admin_test_users(apps, schema_editor):
+    DjangoUser = apps.get_model("auth", "User")
+    LotusUser = apps.get_model("core", "User")
+
+    emails = [user_data["email"] for user_data in SEEDED_USERS]
+
+    DjangoUser.objects.filter(username__in=emails).delete()
+    LotusUser.objects.filter(email__in=emails).delete()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("core", "0021_seed_community_pulse_flag"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            seed_ml_model_admin_test_users,
+            reverse_seed_ml_model_admin_test_users,
+        ),
+    ]

--- a/services/django/core/signals.py
+++ b/services/django/core/signals.py
@@ -4,9 +4,10 @@ Keeps Django auth.User in sync with core.User for admin access.
 """
 
 from django.contrib.auth.models import User as DjangoUser
-from django.db.models.signals import post_delete, post_save, pre_save
+from django.db.models.signals import m2m_changed, post_delete, post_save, pre_save
 from django.dispatch import receiver
 
+from .auth_utils import desired_django_access_flags
 from .models import User as LotusUser
 
 # Store old email before save to handle email updates
@@ -32,8 +33,6 @@ def sync_django_user(sender, instance, created, **kwargs):
     - Admin role users get is_staff=True and is_superuser=True
     - Other users get basic Django User (created for consistency)
     """
-    from django.conf import settings
-
     # Get old email if this was an update
     old_email = _old_email_cache.pop(instance.pk, None) if not created else None
 
@@ -54,11 +53,35 @@ def sync_django_user(sender, instance, created, **kwargs):
         django_user.email = instance.email
         django_user.save()
 
-    # Set admin privileges based on role
-    is_admin = instance.role == getattr(settings, "ADMIN_ROLE_NAME", "Admin")
-    django_user.is_staff = is_admin
-    django_user.is_superuser = is_admin
+    is_staff, is_superuser = desired_django_access_flags(
+        django_user=django_user,
+        lotus_user=instance,
+    )
+    django_user.is_staff = is_staff
+    django_user.is_superuser = is_superuser
     django_user.save()
+
+
+@receiver(m2m_changed, sender=DjangoUser.groups.through)
+def sync_django_user_group_access(sender, instance, action, **kwargs):
+    """Keep Django staff access aligned when admin-allowed groups change."""
+    if action not in {"post_add", "post_remove", "post_clear"}:
+        return
+
+    lotus_user = LotusUser.objects.filter(email=instance.email).first()
+    if not lotus_user:
+        return
+
+    is_staff, is_superuser = desired_django_access_flags(
+        django_user=instance,
+        lotus_user=lotus_user,
+    )
+    if instance.is_staff == is_staff and instance.is_superuser == is_superuser:
+        return
+
+    instance.is_staff = is_staff
+    instance.is_superuser = is_superuser
+    instance.save(update_fields=["is_staff", "is_superuser"])
 
 
 @receiver(post_delete, sender=LotusUser)

--- a/services/django/tests/test_active_ml_model_admin.py
+++ b/services/django/tests/test_active_ml_model_admin.py
@@ -98,6 +98,34 @@ class TestActiveMLModelAdmin:
         assert response.status_code == 200
         assert "test_model" in response.content.decode()
 
+    def test_product_manager_group_can_see_model_on_admin_index(self, client):
+        from django.core.cache import cache
+
+        cache.clear()
+
+        group, _ = Group.objects.get_or_create(name="product")
+        django_user = DjangoUser.objects.create_user(
+            username="pm_index_user",
+            email="pm-index@test.com",
+            password="testpass123",
+        )
+        django_user.groups.add(group)
+        django_user.save()
+
+        LotusUser.objects.get_or_create(
+            email="pm-index@test.com",
+            defaults={"role": "Consumer", "timezone": "UTC"},
+        )
+
+        client.force_login(django_user)
+
+        url = reverse("lotus_admin:index")
+        changelist_url = reverse("lotus_admin:core_activemlmodel_changelist")
+        response = client.get(url)
+
+        assert response.status_code == 200
+        assert changelist_url in response.content.decode()
+
     def test_product_manager_group_can_add(self, client):
         from django.core.cache import cache
 
@@ -272,6 +300,34 @@ class TestActiveMLModelAdmin:
         response = client.get(url)
         assert response.status_code == 200
         assert "test_model" in response.content.decode()
+
+    def test_ml_engineer_group_can_see_model_on_admin_index(self, client):
+        from django.core.cache import cache
+
+        cache.clear()
+
+        group, _ = Group.objects.get_or_create(name="ml_ops")
+        django_user = DjangoUser.objects.create_user(
+            username="ml_index_user",
+            email="ml-index@test.com",
+            password="testpass123",
+        )
+        django_user.groups.add(group)
+        django_user.save()
+
+        LotusUser.objects.get_or_create(
+            email="ml-index@test.com",
+            defaults={"role": "Consumer", "timezone": "UTC"},
+        )
+
+        client.force_login(django_user)
+
+        url = reverse("lotus_admin:index")
+        changelist_url = reverse("lotus_admin:core_activemlmodel_changelist")
+        response = client.get(url)
+
+        assert response.status_code == 200
+        assert changelist_url in response.content.decode()
 
     def test_ml_engineer_group_can_add(self, client):
         from django.core.cache import cache

--- a/services/django/tests/test_management_commands.py
+++ b/services/django/tests/test_management_commands.py
@@ -11,7 +11,10 @@ from core.models import (
     Journal,
     User as LotusUser,
 )
-from django.contrib.auth.models import User as DjangoUser
+from django.contrib.auth.models import (
+    Group,
+    User as DjangoUser,
+)
 from django.core.management import call_command
 from django.core.management.base import CommandError
 import pytest
@@ -329,6 +332,31 @@ class TestSyncDjangoUsersCommand:
         assert "sync_new@test.com" in output
         assert "sync_update@test.com" in output
         assert "sync_skip@test.com" in output
+
+    def test_sync_django_users_preserves_staff_for_allowed_group_user(self):
+        """Allowed stakeholder groups should keep Django staff access after sync."""
+        lotus_user = LotusUser.objects.create(
+            email="stakeholder@test.com",
+            role="Consumer",
+            timezone="UTC",
+        )
+        django_user = DjangoUser.objects.get(username="stakeholder@test.com")
+        product_group, _ = Group.objects.get_or_create(name="product")
+        django_user.groups.add(product_group)
+
+        django_user.refresh_from_db()
+        assert django_user.is_staff is True
+        assert django_user.is_superuser is False
+
+        out = StringIO()
+        call_command("sync_django_users", stdout=out)
+
+        django_user.refresh_from_db()
+        assert django_user.is_staff is True
+        assert django_user.is_superuser is False
+
+        output = out.getvalue()
+        assert f"Skipped {lotus_user.email} (already in sync)" in output
 
 
 @pytest.mark.django_db

--- a/services/django/tests/test_signals.py
+++ b/services/django/tests/test_signals.py
@@ -3,7 +3,10 @@ Tests for Django User synchronization signals.
 """
 
 from core.models import User as LotusUser
-from django.contrib.auth.models import User as DjangoUser
+from django.contrib.auth.models import (
+    Group,
+    User as DjangoUser,
+)
 from django.test import override_settings
 import pytest
 
@@ -16,7 +19,7 @@ class TestSyncDjangoUserSignal:
         self,
     ):
         """Creating a LotusUser with Admin role should create Django User with is_staff=True and is_superuser=True."""
-        lotus_user = LotusUser.objects.create(
+        LotusUser.objects.create(
             email="admin@test.com",
             role="Admin",
             timezone="UTC",
@@ -31,7 +34,7 @@ class TestSyncDjangoUserSignal:
         self,
     ):
         """Creating a LotusUser with Consumer role should create Django User with is_staff=False and is_superuser=False."""
-        lotus_user = LotusUser.objects.create(
+        LotusUser.objects.create(
             email="consumer@test.com",
             role="Consumer",
             timezone="UTC",
@@ -46,7 +49,7 @@ class TestSyncDjangoUserSignal:
         self,
     ):
         """Creating a LotusUser with a custom role should create Django User without admin privileges."""
-        lotus_user = LotusUser.objects.create(
+        LotusUser.objects.create(
             email="custom@test.com",
             role="CustomRole",
             timezone="UTC",
@@ -60,7 +63,7 @@ class TestSyncDjangoUserSignal:
     @override_settings(ADMIN_ROLE_NAME="SuperAdmin")
     def test_create_lotus_user_with_custom_admin_role_name(self):
         """Creating a LotusUser with custom ADMIN_ROLE_NAME should grant admin privileges."""
-        lotus_user = LotusUser.objects.create(
+        LotusUser.objects.create(
             email="superadmin@test.com",
             role="SuperAdmin",
             timezone="UTC",
@@ -169,22 +172,47 @@ class TestSyncDjangoUserSignal:
         existing_django_user.save()
 
         # Create LotusUser with same email
-        lotus_user = LotusUser.objects.create(
+        LotusUser.objects.create(
             email="existing@test.com",
             role="Admin",
             timezone="UTC",
         )
 
         # Should update existing Django User, not create new one
-        django_user_count = DjangoUser.objects.filter(
-            username="existing@test.com"
-        ).count()
+        django_user_count = DjangoUser.objects.filter(username="existing@test.com").count()
         assert django_user_count == 1
 
         existing_django_user.refresh_from_db()
         assert existing_django_user.email == "existing@test.com"
         assert existing_django_user.is_staff is True
         assert existing_django_user.is_superuser is True
+
+    def test_allowed_group_membership_grants_staff_without_superuser(self):
+        """Adding an allowed admin group should grant Django staff access."""
+        lotus_user = LotusUser.objects.create(
+            email="product_group@test.com",
+            role="Consumer",
+            timezone="UTC",
+        )
+
+        django_user = DjangoUser.objects.get(username="product_group@test.com")
+        assert django_user.is_staff is False
+        assert django_user.is_superuser is False
+
+        product_group, _ = Group.objects.get_or_create(name="product")
+        django_user.groups.add(product_group)
+
+        django_user.refresh_from_db()
+        assert django_user.is_staff is True
+        assert django_user.is_superuser is False
+
+        lotus_user.refresh_from_db()
+        lotus_user.timezone = "America/Los_Angeles"
+        lotus_user.save()
+
+        django_user.refresh_from_db()
+        assert django_user.is_staff is True
+        assert django_user.is_superuser is False
 
 
 @pytest.mark.django_db

--- a/services/frontend/__tests__/app/page.test.tsx
+++ b/services/frontend/__tests__/app/page.test.tsx
@@ -87,6 +87,7 @@ describe("LoggedInDashboard", () => {
       <LoggedInDashboard
         analytics={mockAnalytics}
         recentJournals={mockJournals}
+        showCommunityPulse={true}
         todayTogether={mockTodayTogether}
         userName="John"
         timezone="UTC"
@@ -101,6 +102,7 @@ describe("LoggedInDashboard", () => {
       <LoggedInDashboard
         analytics={mockAnalytics}
         recentJournals={mockJournals}
+        showCommunityPulse={true}
         todayTogether={mockTodayTogether}
         timezone="UTC"
       />,
@@ -114,19 +116,17 @@ describe("LoggedInDashboard", () => {
       <LoggedInDashboard
         analytics={mockAnalytics}
         recentJournals={mockJournals}
+        showCommunityPulse={true}
         todayTogether={mockTodayTogether}
         userName="John"
         timezone="UTC"
       />,
     );
 
-    // Check stats labels are displayed
     expect(screen.getByText("Last 30 Days")).toBeInTheDocument();
     expect(screen.getByText("Current Streak")).toBeInTheDocument();
     expect(screen.getByText("Mood Trend")).toBeInTheDocument();
     expect(screen.getByText("Total Entries")).toBeInTheDocument();
-
-    // Check writing stats section
     expect(screen.getByText("Writing Stats")).toBeInTheDocument();
     expect(screen.getByText("Total entries:")).toBeInTheDocument();
     expect(screen.getByText("Active days:")).toBeInTheDocument();
@@ -137,6 +137,7 @@ describe("LoggedInDashboard", () => {
       <LoggedInDashboard
         analytics={mockAnalytics}
         recentJournals={mockJournals}
+        showCommunityPulse={true}
         todayTogether={mockTodayTogether}
         userName="John"
         timezone="UTC"
@@ -144,7 +145,6 @@ describe("LoggedInDashboard", () => {
     );
 
     expect(screen.getByText("Recent Entries")).toBeInTheDocument();
-    // Check entry previews are rendered
     expect(
       screen.getByText(/This is my first journal entry/),
     ).toBeInTheDocument();
@@ -155,6 +155,7 @@ describe("LoggedInDashboard", () => {
       <LoggedInDashboard
         analytics={null}
         recentJournals={[]}
+        showCommunityPulse={false}
         todayTogether={null}
         userName="John"
         timezone="UTC"
@@ -170,6 +171,7 @@ describe("LoggedInDashboard", () => {
       <LoggedInDashboard
         analytics={mockAnalytics}
         recentJournals={mockJournals}
+        showCommunityPulse={true}
         todayTogether={mockTodayTogether}
         userName="John"
         timezone="UTC"
@@ -184,6 +186,7 @@ describe("LoggedInDashboard", () => {
       <LoggedInDashboard
         analytics={mockAnalytics}
         recentJournals={mockJournals}
+        showCommunityPulse={true}
         todayTogether={mockTodayTogether}
         userName="John"
         timezone="UTC"
@@ -200,6 +203,7 @@ describe("LoggedInDashboard", () => {
       <LoggedInDashboard
         analytics={mockAnalytics}
         recentJournals={mockJournals}
+        showCommunityPulse={true}
         todayTogether={mockTodayTogether}
         userName="John"
         timezone="UTC"
@@ -211,5 +215,23 @@ describe("LoggedInDashboard", () => {
       screen.getByText("People are trying to soften the pace today."),
     ).toBeInTheDocument();
     expect(screen.getByText("Explore Community Pulse")).toBeInTheDocument();
+  });
+
+  test("hides the Today, Together community card when disabled", () => {
+    render(
+      <LoggedInDashboard
+        analytics={mockAnalytics}
+        recentJournals={mockJournals}
+        showCommunityPulse={false}
+        todayTogether={mockTodayTogether}
+        userName="John"
+        timezone="UTC"
+      />,
+    );
+
+    expect(screen.queryByText("Today, Together")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("Explore Community Pulse"),
+    ).not.toBeInTheDocument();
   });
 });

--- a/services/frontend/__tests__/components/profile/ProfileSettingsClient.test.tsx
+++ b/services/frontend/__tests__/components/profile/ProfileSettingsClient.test.tsx
@@ -33,6 +33,7 @@ describe("ProfileSettingsClient", () => {
     render(
       <ProfileSettingsClient
         timezone="UTC"
+        showCommunityPulse={true}
         communityInsightsOptIn={true}
         communityLocationOptIn={false}
         communityCountryCode="US"
@@ -45,5 +46,23 @@ describe("ProfileSettingsClient", () => {
     expect(screen.getByTestId("community-settings-card")).toHaveTextContent(
       "insights:true location:false",
     );
+  });
+
+  it("hides community settings when community pulse is disabled", () => {
+    render(
+      <ProfileSettingsClient
+        timezone="UTC"
+        showCommunityPulse={false}
+        communityInsightsOptIn={true}
+        communityLocationOptIn={false}
+        communityCountryCode="US"
+        communityRegionCode="US-CA"
+      />,
+    );
+
+    expect(screen.getByTestId("timezone-selector")).toHaveTextContent("UTC");
+    expect(
+      screen.queryByTestId("community-settings-card"),
+    ).not.toBeInTheDocument();
   });
 });

--- a/services/frontend/app/(root)/community/page.tsx
+++ b/services/frontend/app/(root)/community/page.tsx
@@ -3,6 +3,7 @@ import { redirect } from "next/navigation";
 import { CommunityPulsePage } from "@/components/community/CommunityPulsePage";
 import { ROUTES } from "@/lib/routes";
 import {
+  fetchFeatureFlags,
   fetchCommunityPrompts,
   fetchCommunityPulse,
   fetchUserCommunitySettings,
@@ -34,6 +35,12 @@ export default async function CommunityPage({
   const session = await auth();
 
   if (!session?.user?.id) {
+    redirect(ROUTES.home);
+  }
+
+  const userRole = session.user.role ?? "";
+  const flags = await fetchFeatureFlags(userRole);
+  if (flags.community_pulse !== true) {
     redirect(ROUTES.home);
   }
 

--- a/services/frontend/app/(root)/journal/create/page.tsx
+++ b/services/frontend/app/(root)/journal/create/page.tsx
@@ -1,6 +1,6 @@
 import { auth } from "@/auth";
 import { redirect } from "next/navigation";
-import { fetchCommunityPrompts } from "@/lib/server";
+import { fetchCommunityPrompts, fetchFeatureFlags } from "@/lib/server";
 import { ROUTES } from "@/lib/routes";
 import CreateJournalPageClient from "@/components/journal/CreateJournalPageClient";
 
@@ -11,10 +11,15 @@ export default async function CreateJournalPage() {
     redirect(ROUTES.home);
   }
 
-  const communityPromptSet = await fetchCommunityPrompts(session.user.id, {
-    surface: "journal_create",
-    scope: "nearby",
-  });
+  const userRole = session.user.role ?? "";
+  const flags = await fetchFeatureFlags(userRole);
+  const communityPromptSet =
+    flags.community_pulse === true
+      ? await fetchCommunityPrompts(session.user.id, {
+          surface: "journal_create",
+          scope: "nearby",
+        })
+      : null;
 
   return <CreateJournalPageClient communityPromptSet={communityPromptSet} />;
 }

--- a/services/frontend/app/(root)/page.tsx
+++ b/services/frontend/app/(root)/page.tsx
@@ -1,5 +1,6 @@
 import { auth } from "@/auth";
 import {
+  fetchFeatureFlags,
   fetchUserAnalytics,
   fetchRecentJournals,
   fetchTodayTogether,
@@ -15,17 +16,26 @@ export default async function HomePage() {
     return <LandingPage />;
   }
 
-  // Fetch data in parallel on the server
+  const userRole = session.user.role ?? "";
+  const analyticsPromise = fetchUserAnalytics(session.user.id);
+  const recentJournalsPromise = fetchRecentJournals(session.user.id, 5);
+  const flags = await fetchFeatureFlags(userRole);
+  const showCommunityPulse = flags.community_pulse === true;
+  const todayTogetherPromise = showCommunityPulse
+    ? fetchTodayTogether(session.user.id, "nearby")
+    : Promise.resolve(null);
+
   const [analytics, recentJournals, todayTogether] = await Promise.all([
-    fetchUserAnalytics(session.user.id),
-    fetchRecentJournals(session.user.id, 5),
-    fetchTodayTogether(session.user.id, "nearby"),
+    analyticsPromise,
+    recentJournalsPromise,
+    todayTogetherPromise,
   ]);
 
   return (
     <LoggedInDashboard
       analytics={analytics}
       recentJournals={recentJournals}
+      showCommunityPulse={showCommunityPulse}
       todayTogether={todayTogether}
       userName={session.user.name ?? undefined}
       timezone={session.user.timezone ?? "UTC"}

--- a/services/frontend/app/(root)/profile/settings/page.tsx
+++ b/services/frontend/app/(root)/profile/settings/page.tsx
@@ -1,7 +1,7 @@
 import { auth } from "@/auth";
 import { redirect } from "next/navigation";
 import { ProfileSettingsClient } from "@/components/profile/ProfileSettingsClient";
-import { fetchUserCommunitySettings } from "@/lib/server";
+import { fetchFeatureFlags, fetchUserCommunitySettings } from "@/lib/server";
 import { ROUTES } from "@/lib/routes";
 
 export default async function ProfileSettingsPage() {
@@ -12,11 +12,17 @@ export default async function ProfileSettingsPage() {
   }
 
   const timezone = session.user?.timezone ?? "UTC";
-  const settings = await fetchUserCommunitySettings(session.user.email ?? "");
+  const userRole = session.user.role ?? "";
+  const flags = await fetchFeatureFlags(userRole);
+  const showCommunityPulse = flags.community_pulse === true;
+  const settings = showCommunityPulse
+    ? await fetchUserCommunitySettings(session.user.email ?? "")
+    : null;
 
   return (
     <ProfileSettingsClient
       timezone={timezone}
+      showCommunityPulse={showCommunityPulse}
       communityInsightsOptIn={settings?.communityInsightsOptIn ?? false}
       communityLocationOptIn={settings?.communityLocationOptIn ?? false}
       communityCountryCode={settings?.communityCountryCode ?? ""}

--- a/services/frontend/components/dashboard/LoggedInDashboard.tsx
+++ b/services/frontend/components/dashboard/LoggedInDashboard.tsx
@@ -28,6 +28,7 @@ interface LoggedInDashboardProps {
   recentJournals: JournalEntry[];
   userName?: string;
   timezone?: string;
+  showCommunityPulse: boolean;
   todayTogether?: TodayTogetherData | null;
 }
 
@@ -36,6 +37,7 @@ export const LoggedInDashboard = ({
   recentJournals,
   userName,
   timezone,
+  showCommunityPulse,
   todayTogether = null,
 }: LoggedInDashboardProps) => {
   // Derive display values from analytics (or use defaults for new users)
@@ -98,7 +100,7 @@ export const LoggedInDashboard = ({
           </Link>
         </div>
 
-        <TodayTogetherCard snapshot={todayTogether} />
+        {showCommunityPulse && <TodayTogetherCard snapshot={todayTogether} />}
 
         {/* Stats Overview */}
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">

--- a/services/frontend/components/profile/ProfileSettingsClient.tsx
+++ b/services/frontend/components/profile/ProfileSettingsClient.tsx
@@ -8,6 +8,7 @@ import { ROUTES } from "@/lib/routes";
 
 interface ProfileSettingsClientProps {
   timezone: string;
+  showCommunityPulse: boolean;
   communityInsightsOptIn: boolean;
   communityLocationOptIn: boolean;
   communityCountryCode: string;
@@ -16,6 +17,7 @@ interface ProfileSettingsClientProps {
 
 export function ProfileSettingsClient({
   timezone,
+  showCommunityPulse,
   communityInsightsOptIn,
   communityLocationOptIn,
   communityCountryCode,
@@ -46,16 +48,18 @@ export function ProfileSettingsClient({
           </CardContent>
         </Card>
 
-        <Card>
-          <CardContent className="p-6">
-            <CommunitySettingsCard
-              initialInsightsOptIn={communityInsightsOptIn}
-              initialLocationOptIn={communityLocationOptIn}
-              initialCountryCode={communityCountryCode}
-              initialRegionCode={communityRegionCode}
-            />
-          </CardContent>
-        </Card>
+        {showCommunityPulse && (
+          <Card>
+            <CardContent className="p-6">
+              <CommunitySettingsCard
+                initialInsightsOptIn={communityInsightsOptIn}
+                initialLocationOptIn={communityLocationOptIn}
+                initialCountryCode={communityCountryCode}
+                initialRegionCode={communityRegionCode}
+              />
+            </CardContent>
+          </Card>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Description

Adds a Django waffle flag for community pulse and gates the frontend community pulse surfaces behind that flag.

### Added

- A seeded `community_pulse` waffle flag in Django.
- Migration for Product + ML Ops Example Users, and a `README.md` note on how they can be used in Django Admin

### Updated

- Gated the dashboard, community page, journal prompts, and profile community settings behind the evaluated feature flag.
- Added frontend tests covering the enabled and disabled community pulse states.
