### PR TITLE
chore: remove low-value AI-generated comments across services

### DIFF
--- a/services/analyzer/src/clients/base_mlflow_client.py
+++ b/services/analyzer/src/clients/base_mlflow_client.py
@@ -62,7 +62,6 @@ class BaseMLflowClient:
                     "even after bypassing @trace_disabled — unexpected MLflow 3.x state."
                 )
 
-            # Get actual model version info - pass tracking URI explicitly
             client = mlflow.MlflowClient(tracking_uri=self.mlflow_uri)
             if model_version == "latest":
                 try:
@@ -80,7 +79,6 @@ class BaseMLflowClient:
             else:
                 self.model_version = model_version
 
-            # Get additional model metadata
             try:
                 model_version_details = client.get_model_version(
                     self.model_name, self.model_version

--- a/services/analyzer/src/clients/ml_sentiment_client.py
+++ b/services/analyzer/src/clients/ml_sentiment_client.py
@@ -21,7 +21,6 @@ class SentimentClient(BaseMLflowClient):
         mlflow_uri: str | None = None,
     ):
         super().__init__(model_name="journal_sentiment_analyzer", mlflow_uri=mlflow_uri)
-        # Minimum confidence for reliable classification
         self.min_confidence_threshold = 0.4
 
     def predict_sentiment(self, text: str) -> dict[str, Any]:
@@ -37,14 +36,11 @@ class SentimentClient(BaseMLflowClient):
         if not self.is_ready():
             raise RuntimeError("SentimentClient model not loaded. Call load_model() first.")
 
-        # Create DataFrame input for pyfunc model
         input_df = pd.DataFrame({"text": [text]})
 
-        # Model returns list of prediction dicts
         results = self.model.predict(input_df)
         result = results[0] if results else {}
 
-        # Add model version and reliability check
         confidence = result.get("confidence", 0.0)
         is_reliable = confidence >= self.min_confidence_threshold
 
@@ -68,7 +64,6 @@ class SentimentClient(BaseMLflowClient):
         input_df = pd.DataFrame({"text": texts})
         results = self.model.predict(input_df)
 
-        # Add model version and reliability check to each result
         processed_results = []
         for result in results:
             confidence = result.get("confidence", 0.0)
@@ -131,11 +126,9 @@ class SentimentClient(BaseMLflowClient):
         if not self.is_ready():
             raise RuntimeError("SentimentClient model not loaded. Call load_model() first.")
 
-        # Batch predict all sentiments
         texts = [entry["text"] for entry in entries_with_dates]
         predictions = self.predict_sentiment_batch(texts)
 
-        # Combine predictions with dates
         results = []
         sentiment_counts = {"positive": 0, "negative": 0, "neutral": 0, "uncertain": 0}
         total_confidence = 0
@@ -158,7 +151,6 @@ class SentimentClient(BaseMLflowClient):
             reliable_predictions / len(entries_with_dates) if entries_with_dates else 0
         )
 
-        # Determine dominant sentiment (excluding uncertain)
         reliable_counts = {k: v for k, v in sentiment_counts.items() if k != "uncertain"}
         dominant_sentiment = (
             max(reliable_counts, key=reliable_counts.get)

--- a/services/analyzer/src/crud/journal_sentiments.py
+++ b/services/analyzer/src/crud/journal_sentiments.py
@@ -19,7 +19,6 @@ def create_or_update_sentiment(
     try:
         model_version = sentiment_data["ml_model_version"]
 
-        # Check for existing sentiment analysis
         existing = (
             db.query(JournalSentiments)
             .filter(
@@ -33,7 +32,6 @@ def create_or_update_sentiment(
 
         if existing:
             if force_update:
-                # Update existing record
                 existing.sentiment = sentiment_data["sentiment"]
                 existing.confidence = sentiment_data["confidence"]
                 existing.confidence_level = sentiment_data["confidence_level"]
@@ -43,13 +41,11 @@ def create_or_update_sentiment(
                 sentiment_record = existing
                 logger.info(f"Updated sentiment for journal {journal_id}, model {model_version}")
             else:
-                # Return existing without updating
                 logger.info(
                     f"Sentiment already exists for journal {journal_id}, model {model_version}"
                 )
                 return existing
         else:
-            # Create new record
             sentiment_record = JournalSentiments(
                 journal_id=journal_id,
                 sentiment=sentiment_data["sentiment"],
@@ -82,7 +78,6 @@ def get_sentiment_by_journal_id(
         if model_version:
             query = query.filter(JournalSentiments.ml_model_version == model_version)
 
-        # Get the most recent analysis
         sentiment = query.order_by(desc(JournalSentiments.created_at)).first()
 
         if sentiment:
@@ -128,21 +123,18 @@ def get_sentiment_trends(
 ) -> list[dict[str, Any]]:
     """Get sentiment trends over time."""
     try:
-        # Calculate date range
         end_date = datetime.now()
         start_date = end_date - timedelta(days=days_back)
 
-        # Build query
         query = db.query(JournalSentiments).filter(JournalSentiments.created_at >= start_date)
 
         if reliable_only:
             query = query.filter(JournalSentiments.is_reliable is True)
 
-        # Add user filter if provided (assuming journals table has user_id)
+        # TODO: add user filter once journals table join is wired up
         # if user_id:
         #     query = query.join(Journal).filter(Journal.user_id == user_id)
 
-        # Group by time period
         if group_by == "day":
             time_group = func.date_trunc("day", JournalSentiments.created_at)
         elif group_by == "week":
@@ -152,7 +144,6 @@ def get_sentiment_trends(
         else:
             raise ValueError("group_by must be 'day', 'week', or 'month'")
 
-        # Execute aggregation query
         results = (
             db.query(
                 time_group.label("period"),
@@ -166,7 +157,6 @@ def get_sentiment_trends(
             .all()
         )
 
-        # Transform results into response format
         trends_dict = {}
         for period, sentiment, count, avg_conf in results:
             period_str = period.strftime("%Y-%m-%d")
@@ -188,7 +178,6 @@ def get_sentiment_trends(
             trends_dict[period_str]["total_entries"] += count
             trends_dict[period_str]["avg_confidence"] = float(avg_conf or 0)
 
-        # Determine dominant sentiment for each period
         trends = []
         for period_data in trends_dict.values():
             sentiment_counts = period_data["sentiment_counts"]
@@ -221,19 +210,16 @@ def get_sentiment_stats(
 ) -> dict[str, Any]:
     """Get overall sentiment analysis statistics."""
     try:
-        # Build base query
         query = db.query(JournalSentiments)
 
-        # Add date filter if provided
         if days_back:
             start_date = datetime.now() - timedelta(days=days_back)
             query = query.filter(JournalSentiments.created_at >= start_date)
 
-        # Add user filter if provided (assuming journals table has user_id)
+        # TODO: add user filter once journals table join is wired up
         # if user_id:
         #     query = query.join(Journal).filter(Journal.user_id == user_id)
 
-        # Get all records
         all_sentiments = query.all()
 
         if not all_sentiments:
@@ -252,13 +238,11 @@ def get_sentiment_stats(
                 "latest_model_version": None,
             }
 
-        # Calculate statistics
         total_analyzed = len(all_sentiments)
         reliable_sentiments = [s for s in all_sentiments if s.is_reliable]
         reliable_count = len(reliable_sentiments)
         reliability_rate = reliable_count / total_analyzed if total_analyzed > 0 else 0
 
-        # Sentiment distribution
         sentiment_distribution = {
             "positive": 0,
             "negative": 0,
@@ -275,7 +259,6 @@ def get_sentiment_stats(
 
         avg_confidence = total_confidence / total_analyzed if total_analyzed > 0 else 0
 
-        # Get latest model version
         latest_sentiment = max(all_sentiments, key=lambda s: s.created_at)
         latest_model_version = latest_sentiment.ml_model_version
 
@@ -309,7 +292,7 @@ def get_recent_sentiments(
         if reliable_only:
             query = query.filter(JournalSentiments.is_reliable is True)
 
-        # Add user filter if provided (assuming journals table has user_id)
+        # TODO: add user filter once journals table join is wired up
         # if user_id:
         #     query = query.join(Journal).filter(Journal.user_id == user_id)
 

--- a/services/analyzer/src/crud/journal_topics.py
+++ b/services/analyzer/src/crud/journal_topics.py
@@ -12,13 +12,11 @@ def create_or_update_topics(
 ) -> list[JournalTopics]:
     """Create or update topics for a journal entry."""
     try:
-        # Delete existing topics for this journal
         db.query(JournalTopics).filter(JournalTopics.journal_id == journal_id).delete()
 
-        # Create new topic records (topic_name stored lowercase for consistency)
+        # topic_name/subtopic_name are stored lowercase for consistent matching.
         topic_records = []
         for topic in topics:
-            # always lowercase the topic name for standardization.
             topic_name = str(topic["topic_name"]).strip().lower()
             raw_subtopic = topic.get("subtopic_name")
             subtopic_name = str(raw_subtopic).strip().lower() if raw_subtopic else None

--- a/services/analyzer/src/routers/v1/journal_sentiments.py
+++ b/services/analyzer/src/routers/v1/journal_sentiments.py
@@ -104,7 +104,6 @@ def update_journal_sentiment(
 ):
     """Re-analyze and update sentiment for a journal entry"""
 
-    # Force reanalyze when updating
     request.force_reanalyze = True
     return analyze_journal_sentiment(journal_id, request, sentiment_client, db)
 
@@ -145,7 +144,6 @@ def analyze_journals_sentiment_batch(
 ):
     """Analyze sentiment for multiple journal entries"""
 
-    # Fetch all journals
     journals = db.query(Journals).filter(Journals.id.in_(request.journal_ids)).all()
     found_ids = {j.id for j in journals}
     missing_ids = set(request.journal_ids) - found_ids
@@ -159,14 +157,12 @@ def analyze_journals_sentiment_batch(
     results = []
     for journal in journals:
         try:
-            # Run sentiment analysis
             with tracer.start_as_current_span("sentiment.predict") as span:
                 span.set_attribute("journal.id", journal.id)
                 analysis_result = sentiment_client.predict_sentiment(journal.journal_text)
                 span.set_attribute("sentiment.label", analysis_result.get("label", ""))
                 span.set_attribute("sentiment.score", float(analysis_result.get("score", 0)))
 
-            # Store result
             sentiment_record = create_or_update_sentiment(
                 db=db,
                 journal_id=journal.id,
@@ -177,7 +173,6 @@ def analyze_journals_sentiment_batch(
 
         except Exception as e:
             logger.error(f"Failed to analyze journal {journal.id}: {e}")
-            # Continue with other journals, don't fail entire batch
             continue
 
     logger.info(f"Successfully analyzed {len(results)} out of {len(request.journal_ids)} journals")
@@ -206,7 +201,6 @@ def get_sentiment_trends_endpoint(
             user_id=user_id,
         )
 
-        # Convert to Pydantic models
         trends = [
             SentimentTrendResponse(
                 period=trend["period"],

--- a/services/analyzer/src/routers/v1/journal_topics.py
+++ b/services/analyzer/src/routers/v1/journal_topics.py
@@ -64,7 +64,6 @@ def extract_journal_topics(
         raise HTTPException(status_code=503, detail="Topic extraction service unavailable")
 
     try:
-        # Get the journal entry
         journal = get_journal_by_id(db, journal_id)
         if not journal:
             raise HTTPException(status_code=404, detail="Journal not found")
@@ -77,14 +76,12 @@ def extract_journal_topics(
                 "flags.types", ",".join(flag.flag_type for flag in detection_result.flags)
             )
 
-        # Extract topics from the journal content (includes model version)
         with tracer.start_as_current_span("topics.extract") as span:
             span.set_attribute("journal.id", journal_id)
             span.set_attribute("model.version", topic_client.model_version or "")
             topics = topic_client.extract_topics(journal.journal_text)
             span.set_attribute("topics.count", len(topics))
 
-        # Store topics in database
         create_or_update_topics(db, journal_id, topics)
 
         if detection_result.flags:
@@ -119,7 +116,6 @@ def get_journal_topics(
         raise HTTPException(status_code=404, detail="Journal not found")
 
     try:
-        # Get stored topics from database
         topics = get_topics_by_journal_id(db, journal_id)
 
         return {

--- a/services/analyzer/tests/conftest.py
+++ b/services/analyzer/tests/conftest.py
@@ -91,17 +91,14 @@ class MockPyfuncSentimentModel:
         results = []
 
         for text in texts:
-            # Preprocess
             processed_text = text.lower().strip()
 
-            # Get prediction and probabilities from sklearn pipeline
             prediction = self.pipeline.predict([processed_text])[0]
             probabilities = self.pipeline.predict_proba([processed_text])[0]
 
             sentiment = self.sentiment_labels[prediction]
             confidence = float(max(probabilities))
 
-            # Determine confidence level
             if confidence >= self.confidence_thresholds["high"]:
                 confidence_level = "high"
             elif confidence >= self.confidence_thresholds["medium"]:
@@ -165,11 +162,6 @@ class MockSemanticTopicModel:
         return results
 
 
-# ---------------------------------------------------------------------------
-# Testcontainers: Postgres
-# ---------------------------------------------------------------------------
-
-
 @pytest.fixture(scope="session")
 def postgres_container():
     """Spin up an isolated Postgres container for the entire test session."""
@@ -219,11 +211,6 @@ def test_db_session(test_engine):
     session.close()
 
 
-# ---------------------------------------------------------------------------
-# Existing fixtures
-# ---------------------------------------------------------------------------
-
-
 @pytest.fixture(scope="session")
 def real_sentiment_client():
     """Load pre-saved sentiment model for testing."""
@@ -236,14 +223,12 @@ def real_sentiment_client():
         with SENTIMENT_MODEL_PATH.open("rb") as f:
             test_pipeline = pickle.load(f)
 
-        # Create client and inject mock pyfunc model
         client = SentimentClient()
         client.model = MockPyfuncSentimentModel(test_pipeline)
         client.model_version = "test_v1.0.0"
         client.model_run_id = "test_run_id"
         client._is_loaded = True
 
-        # Verify it works
         test_result = client.predict_sentiment("This is a test")
         assert "sentiment" in test_result
 
@@ -268,7 +253,6 @@ def real_topic_client():
     client.model_run_id = "test_run_id"
     client._is_loaded = True
 
-    # Verify it works
     test_result = client.extract_topics("This is a test entry about work")
     assert isinstance(test_result, list)
 
@@ -287,7 +271,6 @@ def override_db_dependency(test_db_session):
 
     yield test_db_session
 
-    # Clean up dependency override
     if get_db in app.dependency_overrides:
         del app.dependency_overrides[get_db]
 
@@ -370,7 +353,6 @@ def mock_openai_topic_client():
     """Mock OpenAI topic client with realistic responses."""
 
     async def mock_analyze_topics(request):
-        # Return realistic mock data based on request
         if "work" in request.text.lower() or "meeting" in request.text.lower():
             return TopicAnalysis(
                 topics=["work", "stress", "meetings", "productivity", "deadlines"][
@@ -385,7 +367,6 @@ def mock_openai_topic_client():
                 ],
                 confidence_scores=[0.92, 0.89, 0.85, 0.80, 0.75][: request.max_topics],
             )
-        # Generic response
         return TopicAnalysis(
             topics=["general", "life", "thoughts", "feelings", "day"][: request.max_topics],
             confidence_scores=[0.70, 0.65, 0.60, 0.55, 0.50][: request.max_topics],

--- a/services/analyzer/tests/integration/test_sentiment.py
+++ b/services/analyzer/tests/integration/test_sentiment.py
@@ -98,7 +98,6 @@ def test_batch_sentiment_analysis(client_fixture, real_sentiment_client):
         data = response.json()
         assert len(data) == 3
 
-        # All should have sentiment analysis
         for analysis in data:
             assert "sentiment" in analysis
             assert "confidence" in analysis
@@ -113,13 +112,11 @@ def test_sentiment_trends(client_fixture, real_sentiment_client):
     app.dependency_overrides[get_sentiment_client] = lambda: real_sentiment_client
 
     try:
-        # Analyze a few entries first
         client_fixture.post(
             "/v1/journals/sentiment/analyze-batch",
             json={"journal_ids": [1, 2, 4], "force_reanalyze": False},
         )
 
-        # Get trends
         response = client_fixture.get("/v1/journals/sentiment/trends?days_back=1&group_by=day")
 
         assert response.status_code == 200

--- a/services/analyzer/tests/integration/test_topics.py
+++ b/services/analyzer/tests/integration/test_topics.py
@@ -56,11 +56,9 @@ def test_get_extracted_topics(client_fixture, real_topic_client):
     app.dependency_overrides[get_topic_client] = lambda: real_topic_client
 
     try:
-        # First extract topics
         extract_response = client_fixture.post("/v1/journals/1/topics/internal")
         assert extract_response.status_code == 204
 
-        # Then retrieve them
         get_response = client_fixture.get("/v1/journals/1/topics")
 
         assert get_response.status_code == 200
@@ -69,7 +67,6 @@ def test_get_extracted_topics(client_fixture, real_topic_client):
         assert "topics" in data
         assert isinstance(data["topics"], list)
 
-        # Should have at least one topic
         if data["topics"]:
             topic = data["topics"][0]
             assert "topic_name" in topic
@@ -87,14 +84,12 @@ def test_get_topics_multiple_extractions(client_fixture, real_topic_client):
     app.dependency_overrides[get_topic_client] = lambda: real_topic_client
 
     try:
-        # Extract topics from different journals
         journals_to_test = [1, 2, 3]
 
         for journal_id in journals_to_test:
             extract_response = client_fixture.post(f"/v1/journals/{journal_id}/topics/internal")
             assert extract_response.status_code == 204
 
-            # Verify we can retrieve each one
             get_response = client_fixture.get(f"/v1/journals/{journal_id}/topics")
             assert get_response.status_code == 200
 
@@ -111,7 +106,6 @@ def test_get_topics(client_fixture, real_topic_client):
     app.dependency_overrides[get_topic_client] = lambda: real_topic_client
 
     try:
-        # Try to get topics without extracting first
         response = client_fixture.get("/v1/journals/1/topics")
 
         assert response.status_code == 200

--- a/services/backend/internal/grpc/analytics_service.go
+++ b/services/backend/internal/grpc/analytics_service.go
@@ -44,7 +44,6 @@ func (s *AnalyticsServer) GetUserJournalSummary(ctx context.Context, req *pb.Get
 		DailyStreak:       summary.DailyStreak,
 	}
 
-	// Handle nullable numeric fields
 	if summary.AvgMoodScore.Valid {
 		val := numericToFloat64(summary.AvgMoodScore)
 		pbSummary.AvgMoodScore = &val
@@ -68,7 +67,6 @@ func (s *AnalyticsServer) GetUserJournalSummary(ctx context.Context, req *pb.Get
 		pbSummary.AvgJournalLength = &val
 	}
 
-	// Handle nullable timestamp fields
 	if summary.FirstJournalAt.Valid {
 		val := summary.FirstJournalAt.Time.Format(time.RFC3339)
 		pbSummary.FirstJournalAt = &val
@@ -82,7 +80,6 @@ func (s *AnalyticsServer) GetUserJournalSummary(ctx context.Context, req *pb.Get
 		pbSummary.LastModifiedAt = &val
 	}
 
-	// Handle 30-day metrics
 	if summary.AvgMoodScore30d.Valid {
 		val := numericToFloat64(summary.AvgMoodScore30d)
 		pbSummary.AvgMoodScore_30D = &val
@@ -94,7 +91,6 @@ func (s *AnalyticsServer) GetUserJournalSummary(ctx context.Context, req *pb.Get
 		pbSummary.MaxMoodScore_30D = summary.MaxMoodScore30d
 	}
 
-	// Handle calculated fields
 	if summary.PositivePercentage.Valid {
 		val := numericToFloat64(summary.PositivePercentage)
 		pbSummary.PositivePercentage = &val

--- a/services/backend/internal/grpc/analytics_service_test.go
+++ b/services/backend/internal/grpc/analytics_service_test.go
@@ -40,12 +40,10 @@ func strp(s string) *string { return &s }
 
 func i32p(v int32) *int32 { return &v }
 
-// newAnalyticsTestLogger creates a logger that discards output for testing
 func newAnalyticsTestLogger() *slog.Logger {
 	return slog.New(slog.NewTextHandler(io.Discard, nil))
 }
 
-// analyticsTestCtx returns a context with DB and logger for analytics tests.
 func analyticsTestCtx(mock db.Querier) context.Context {
 	ctx := context.Background()
 	ctx = inject.WithDB(ctx, mock)

--- a/services/backend/internal/grpc/journal_service.go
+++ b/services/backend/internal/grpc/journal_service.go
@@ -28,13 +28,11 @@ type JournalServer struct {
 }
 
 func (s *JournalServer) CreateJournal(ctx context.Context, req *pb.CreateJournalRequest) (*pb.CreateJournalResponse, error) {
-	// parse user_id from string to UUID
 	userID, err := uuid.Parse(req.UserId)
 	if err != nil {
 		return nil, fmt.Errorf("%w: %w", ErrInvalidUserID, err)
 	}
 
-	// parse mood_score from string to integer (1-10 scale)
 	moodScore, err := strconv.Atoi(req.UserMood)
 	if err != nil {
 		return nil, fmt.Errorf("%w: %w", ErrInvalidMoodScore, err)
@@ -43,7 +41,6 @@ func (s *JournalServer) CreateJournal(ctx context.Context, req *pb.CreateJournal
 		return nil, fmt.Errorf("%w: must be 1-10, got %d", ErrInvalidMoodScore, moodScore)
 	}
 
-	// Extract deps after input validation.
 	pgxPool := inject.PgxPoolFrom(ctx)
 	riverClient := inject.RiverClientFrom(ctx)
 
@@ -66,7 +63,6 @@ func (s *JournalServer) CreateJournal(ctx context.Context, req *pb.CreateJournal
 	}
 	journalID := journal.ID
 
-	// Enqueue the analysis job in the same transaction.
 	_, err = riverClient.InsertTx(ctx, tx, jobs.AnalyzeEntryArgs{
 		EntryID: int64(journalID),
 		UserID:  userID.String(),
@@ -85,21 +81,17 @@ func (s *JournalServer) CreateJournal(ctx context.Context, req *pb.CreateJournal
 }
 
 func (s *JournalServer) GetJournals(ctx context.Context, req *pb.GetJournalsRequest) (*pb.GetJournalsResponse, error) {
-	// parse user_id from string to UUID
 	userID, err := uuid.Parse(req.UserId)
 	if err != nil {
 		return nil, fmt.Errorf("%w: %w", ErrInvalidUserID, err)
 	}
 
-	// Extract deps after input validation
 	dbq := inject.DBFrom(ctx)
 
-	// set default pagination values
 	limit := req.Limit
 	if limit <= 0 {
-		limit = 50 // reasonable default
+		limit = 50
 	}
-	// optionally set max limit to prevent abuse
 	if limit > 100 {
 		limit = 100
 	}
@@ -111,13 +103,11 @@ func (s *JournalServer) GetJournals(ctx context.Context, req *pb.GetJournalsRequ
 
 	pgUserID := pgtype.UUID{Bytes: userID, Valid: true}
 
-	// fetch total count and paginated journals (separate calls)
 	totalCount, err := dbq.GetJournalCountByUserId(ctx, pgUserID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get journal count: %w", err)
 	}
 
-	// Use the generated params struct
 	journals, err := dbq.GetJournalsByUserIdPaginated(ctx, db.GetJournalsByUserIdPaginatedParams{
 		UserID: pgUserID,
 		Limit:  limit,
@@ -127,24 +117,21 @@ func (s *JournalServer) GetJournals(ctx context.Context, req *pb.GetJournalsRequ
 		return nil, fmt.Errorf("failed to fetch journals: %w", err)
 	}
 
-	// Fetch topics for these journals (async-populated by analyzer; may be empty)
+	// Topics are populated asynchronously by the analyzer and may be empty.
 	journalIDs := make([]int32, 0, len(journals))
 	for _, j := range journals {
 		journalIDs = append(journalIDs, j.ID)
 	}
 	topicsByJournal := hydrateTopics(ctx, dbq, journalIDs)
 
-	// prepare journal entries for response
 	var journalEntries []*pb.JournalEntry
 	for _, j := range journals {
 		entry := sourceJournalToPB(j, topicsByJournal[j.ID])
 		journalEntries = append(journalEntries, entry)
 	}
 
-	// calculate if there are more results
 	hasMore := int64(len(journalEntries)) == int64(limit) && (int64(offset)+int64(len(journalEntries))) < totalCount
 
-	// return the paginated response
 	return &pb.GetJournalsResponse{
 		Journals:   journalEntries,
 		TotalCount: totalCount,

--- a/services/backend/internal/grpc/journal_service_test.go
+++ b/services/backend/internal/grpc/journal_service_test.go
@@ -26,7 +26,6 @@ func journalPgUUID(u uuid.UUID) pgtype.UUID { return pgtype.UUID{Bytes: u, Valid
 
 func journalPgTS(t time.Time) pgtype.Timestamp { return pgtype.Timestamp{Time: t, Valid: true} }
 
-// journalTestCtx returns a context with all deps needed by the journal service.
 func journalTestCtx(dbMock db.Querier, httpMock inject.HTTPDoer) context.Context {
 	ctx := context.Background()
 	ctx = inject.WithDB(ctx, dbMock)
@@ -36,7 +35,6 @@ func journalTestCtx(dbMock db.Querier, httpMock inject.HTTPDoer) context.Context
 	return ctx
 }
 
-// noopHTTPClient is a simple mock that returns 200 OK for all requests.
 func noopHTTPClient() *mocks.HTTPDoerMock {
 	return &mocks.HTTPDoerMock{
 		DoFunc: func(req *http.Request) (*http.Response, error) {
@@ -93,7 +91,6 @@ func TestJournalServer_CreateJournal_MoodScoreOutOfRange(t *testing.T) {
 }
 
 func TestJournalServer_GetJournals_Success(t *testing.T) {
-	// Arrange
 	userID := uuid.New()
 	now := time.Now()
 
@@ -139,17 +136,14 @@ func TestJournalServer_GetJournals_Success(t *testing.T) {
 		Offset: 0,
 	}
 
-	// Act
 	resp, err := server.GetJournals(journalTestCtx(mockQuerier, mockHTTPClient), req)
 
-	// Assert
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 	assert.Len(t, resp.Journals, 2)
 	assert.Equal(t, int64(2), resp.TotalCount)
 	assert.False(t, resp.HasMore)
 
-	// Verify first journal
 	assert.Equal(t, "1", resp.Journals[0].JournalId)
 	assert.Equal(t, "First journal entry", resp.Journals[0].JournalText)
 	assert.Equal(t, "7", resp.Journals[0].UserMood)
@@ -192,7 +186,6 @@ func TestJournalServer_GetJournals_WithTopics(t *testing.T) {
 }
 
 func TestJournalServer_GetJournals_WithPagination(t *testing.T) {
-	// Arrange
 	userID := uuid.New()
 	now := time.Now()
 
@@ -211,7 +204,7 @@ func TestJournalServer_GetJournals_WithPagination(t *testing.T) {
 
 	mockQuerier := &mocks.QuerierMock{
 		GetJournalCountByUserIdFunc: func(ctx context.Context, uid pgtype.UUID) (int64, error) {
-			return 25, nil // Total of 25 journals
+			return 25, nil
 		},
 		GetJournalsByUserIdPaginatedFunc: func(ctx context.Context, arg db.GetJournalsByUserIdPaginatedParams) ([]db.SourceJournal, error) {
 			assert.Equal(t, int32(10), arg.Limit)
@@ -232,19 +225,16 @@ func TestJournalServer_GetJournals_WithPagination(t *testing.T) {
 		Offset: 0,
 	}
 
-	// Act
 	resp, err := server.GetJournals(journalTestCtx(mockQuerier, mockHTTPClient), req)
 
-	// Assert
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 	assert.Len(t, resp.Journals, 10)
 	assert.Equal(t, int64(25), resp.TotalCount)
-	assert.True(t, resp.HasMore) // Should have more results
+	assert.True(t, resp.HasMore)
 }
 
 func TestJournalServer_GetJournals_DefaultLimit(t *testing.T) {
-	// Arrange
 	userID := uuid.New()
 
 	mockQuerier := &mocks.QuerierMock{
@@ -252,7 +242,6 @@ func TestJournalServer_GetJournals_DefaultLimit(t *testing.T) {
 			return 0, nil
 		},
 		GetJournalsByUserIdPaginatedFunc: func(ctx context.Context, arg db.GetJournalsByUserIdPaginatedParams) ([]db.SourceJournal, error) {
-			// Verify default limit is applied (50)
 			assert.Equal(t, int32(50), arg.Limit)
 			return []db.SourceJournal{}, nil
 		},
@@ -266,20 +255,17 @@ func TestJournalServer_GetJournals_DefaultLimit(t *testing.T) {
 
 	req := &pb.GetJournalsRequest{
 		UserId: userID.String(),
-		Limit:  0, // No limit specified
+		Limit:  0,
 		Offset: 0,
 	}
 
-	// Act
 	resp, err := server.GetJournals(journalTestCtx(mockQuerier, mockHTTPClient), req)
 
-	// Assert
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 }
 
 func TestJournalServer_GetJournals_MaxLimit(t *testing.T) {
-	// Arrange
 	userID := uuid.New()
 
 	mockQuerier := &mocks.QuerierMock{
@@ -287,7 +273,6 @@ func TestJournalServer_GetJournals_MaxLimit(t *testing.T) {
 			return 0, nil
 		},
 		GetJournalsByUserIdPaginatedFunc: func(ctx context.Context, arg db.GetJournalsByUserIdPaginatedParams) ([]db.SourceJournal, error) {
-			// Verify max limit is capped at 100
 			assert.Equal(t, int32(100), arg.Limit)
 			return []db.SourceJournal{}, nil
 		},
@@ -301,14 +286,12 @@ func TestJournalServer_GetJournals_MaxLimit(t *testing.T) {
 
 	req := &pb.GetJournalsRequest{
 		UserId: userID.String(),
-		Limit:  500, // Exceeds max
+		Limit:  500,
 		Offset: 0,
 	}
 
-	// Act
 	resp, err := server.GetJournals(journalTestCtx(mockQuerier, mockHTTPClient), req)
 
-	// Assert
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 }
@@ -356,7 +339,6 @@ func TestJournalServer_TriggerJournalAnalysis_JournalNotFound(t *testing.T) {
 }
 
 func TestJournalServer_TriggerJournalAnalysis_InvalidJournalId(t *testing.T) {
-	// Arrange
 	mockQuerier := &mocks.QuerierMock{}
 	mockHTTPClient := noopHTTPClient()
 
@@ -366,10 +348,8 @@ func TestJournalServer_TriggerJournalAnalysis_InvalidJournalId(t *testing.T) {
 		JournalId: "not-a-number",
 	}
 
-	// Act
 	resp, err := server.TriggerJournalAnalysis(journalTestCtx(mockQuerier, mockHTTPClient), req)
 
-	// Assert
 	require.Error(t, err)
 	require.Nil(t, resp)
 	assert.ErrorIs(t, err, internalgrpc.ErrInvalidJournalID)

--- a/services/backend/internal/grpc/user_service.go
+++ b/services/backend/internal/grpc/user_service.go
@@ -37,7 +37,6 @@ func (s *UserServer) CreateUser(ctx context.Context, req *pb.CreateUserRequest) 
 	logger := inject.LoggerFrom(ctx)
 	dbq := inject.DBFrom(ctx)
 
-	// Hash the password using bcrypt (salt is embedded in the hash).
 	hashedPassword, err := utils.HashPassword(req.Password)
 	if err != nil {
 		logger.Error("Failed to hash password", "error", err)
@@ -66,8 +65,6 @@ func (s *UserServer) CreateUserOauth(ctx context.Context, req *pb.CreateUserOaut
 	logger := inject.LoggerFrom(ctx)
 	dbq := inject.DBFrom(ctx)
 
-	// create a structured log w/ `time: xxx`, `level`, `msg`, and `user_info`:`
-	// "user_info":{"email":"user_oauth2@email.com","oauth_provider":"github"}}
 	logger.Info("CreateUser request received",
 		slog.Group("user_info",
 			slog.String("email", req.Email),
@@ -97,7 +94,6 @@ func (s *UserServer) GetUser(ctx context.Context, req *pb.GetUserRequest) (*pb.G
 		return nil, status.Error(codes.InvalidArgument, ErrEmailRequired.Error())
 	}
 
-	// Extract deps after input validation
 	dbq := inject.DBFrom(ctx)
 
 	u, err := dbq.GetUserByEmail(ctx, email)
@@ -134,13 +130,11 @@ func (s *UserServer) GetUser(ctx context.Context, req *pb.GetUserRequest) (*pb.G
 func (s *UserServer) UpdateUserTimezone(ctx context.Context, req *pb.UpdateUserTimezoneRequest) (*pb.UpdateUserTimezoneResponse, error) {
 	logger := inject.LoggerFrom(ctx)
 
-	// Validate user ID
 	userID, err := uuid.Parse(req.GetUserId())
 	if err != nil {
 		return nil, status.Error(codes.InvalidArgument, ErrInvalidUserID.Error())
 	}
 
-	// Validate timezone is a valid IANA timezone name
 	tz := req.GetTimezone()
 	if _, err := time.LoadLocation(tz); err != nil {
 		return nil, status.Error(codes.InvalidArgument, ErrInvalidTimezone.Error())

--- a/services/backend/internal/grpc/user_service_test.go
+++ b/services/backend/internal/grpc/user_service_test.go
@@ -20,12 +20,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// newTestLogger creates a logger that discards output for testing
 func newTestLogger() *slog.Logger {
 	return slog.New(slog.NewTextHandler(io.Discard, nil))
 }
 
-// testCtx returns a context populated with the given DB mock and a discard logger.
 func testCtx(mock db.Querier) context.Context {
 	ctx := context.Background()
 	ctx = inject.WithDB(ctx, mock)
@@ -34,13 +32,11 @@ func testCtx(mock db.Querier) context.Context {
 }
 
 func TestUserServer_CreateUser_Success(t *testing.T) {
-	// Arrange
 	expectedUserID := uuid.New()
 	expectedEmail := "test@example.com"
 
 	mockQuerier := &mocks.QuerierMock{
 		CreateUserFunc: func(ctx context.Context, arg db.CreateUserParams) (db.SourceUser, error) {
-			// Verify the email is passed correctly
 			assert.Equal(t, expectedEmail, arg.Email)
 			require.NotNil(t, arg.Password)
 			assert.Nil(t, arg.Salt) // bcrypt embeds its own salt
@@ -64,20 +60,15 @@ func TestUserServer_CreateUser_Success(t *testing.T) {
 		Password: "securepassword123",
 	}
 
-	// Act
 	resp, err := server.CreateUser(testCtx(mockQuerier), req)
 
-	// Assert
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 	assert.Equal(t, expectedUserID.String(), resp.UserId)
-
-	// Verify the mock was called exactly once
 	assert.Len(t, mockQuerier.CreateUserCalls(), 1)
 }
 
 func TestUserServer_CreateUser_DBError(t *testing.T) {
-	// Arrange
 	mockQuerier := &mocks.QuerierMock{
 		CreateUserFunc: func(ctx context.Context, arg db.CreateUserParams) (db.SourceUser, error) {
 			return db.SourceUser{}, errors.New("database connection failed")
@@ -91,17 +82,14 @@ func TestUserServer_CreateUser_DBError(t *testing.T) {
 		Password: "securepassword123",
 	}
 
-	// Act
 	resp, err := server.CreateUser(testCtx(mockQuerier), req)
 
-	// Assert
 	require.Error(t, err)
 	require.Nil(t, resp)
 	assert.Contains(t, err.Error(), "could not create user")
 }
 
 func TestUserServer_GetUser_Success(t *testing.T) {
-	// Arrange
 	expectedUserID := uuid.New()
 	expectedEmail := "test@example.com"
 	expectedRole := "admin"
@@ -135,10 +123,8 @@ func TestUserServer_GetUser_Success(t *testing.T) {
 		Email: expectedEmail,
 	}
 
-	// Act
 	resp, err := server.GetUser(testCtx(mockQuerier), req)
 
-	// Assert
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 	assert.Equal(t, expectedUserID.String(), resp.UserId)
@@ -149,13 +135,10 @@ func TestUserServer_GetUser_Success(t *testing.T) {
 	assert.True(t, resp.CommunityLocationOptIn)
 	assert.Equal(t, "US", resp.CommunityCountryCode)
 	assert.Equal(t, "US-CA", resp.CommunityRegionCode)
-
-	// Verify the mock was called
 	assert.Len(t, mockQuerier.GetUserByEmailCalls(), 1)
 }
 
 func TestUserServer_GetUser_NotFound(t *testing.T) {
-	// Arrange
 	mockQuerier := &mocks.QuerierMock{
 		GetUserByEmailFunc: func(ctx context.Context, email string) (db.SourceUser, error) {
 			return db.SourceUser{}, pgx.ErrNoRows
@@ -168,17 +151,14 @@ func TestUserServer_GetUser_NotFound(t *testing.T) {
 		Email: "nonexistent@example.com",
 	}
 
-	// Act
 	resp, err := server.GetUser(testCtx(mockQuerier), req)
 
-	// Assert
 	require.Error(t, err)
 	require.Nil(t, resp)
 	assert.Contains(t, err.Error(), "user not found")
 }
 
 func TestUserServer_GetUser_EmptyEmail(t *testing.T) {
-	// Arrange — no DB mock needed; validation fails before DB access.
 	mockQuerier := &mocks.QuerierMock{}
 
 	server := &internalgrpc.UserServer{}
@@ -187,22 +167,15 @@ func TestUserServer_GetUser_EmptyEmail(t *testing.T) {
 		Email: "",
 	}
 
-	// Act — context still needs DB because GetUser extracts it after validation,
-	// but with the new code DB is only extracted after the empty-email check,
-	// so a bare context is sufficient.
 	resp, err := server.GetUser(testCtx(mockQuerier), req)
 
-	// Assert
 	require.Error(t, err)
 	require.Nil(t, resp)
 	assert.Contains(t, err.Error(), "email is required")
-
-	// Verify the mock was NOT called (validation should fail first)
 	assert.Len(t, mockQuerier.GetUserByEmailCalls(), 0)
 }
 
 func TestUserServer_CreateUserOauth_Success(t *testing.T) {
-	// Arrange
 	expectedUserID := uuid.New()
 	expectedEmail := "oauth@example.com"
 	expectedProvider := "github"
@@ -234,15 +207,11 @@ func TestUserServer_CreateUserOauth_Success(t *testing.T) {
 		OauthProvider: expectedProvider,
 	}
 
-	// Act
 	resp, err := server.CreateUserOauth(testCtx(mockQuerier), req)
 
-	// Assert
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 	assert.Equal(t, expectedUserID.String(), resp.UserId)
-
-	// Verify the mock was called exactly once
 	assert.Len(t, mockQuerier.CreateUserOauthCalls(), 1)
 }
 

--- a/services/backend/internal/grpc/util_service.go
+++ b/services/backend/internal/grpc/util_service.go
@@ -37,8 +37,8 @@ func (s *UtilServer) GenerateRandomString(ctx context.Context, req *pb.GenerateR
 	logger := inject.LoggerFrom(ctx)
 	dbq := inject.DBFrom(ctx)
 
-	// This is just an example of how to read and write from the runtime_config table
-	// Read the current runtime config for the "ml" key and log the last run timestamp
+	// Example of reading and writing runtime_config. Reads the current value and
+	// logs the last run timestamp if set, then writes an updated timestamp below.
 	config, err := dbq.GetRuntimeConfigByKey(ctx, runtimeConfigKey)
 	if err != nil && !errors.Is(err, pgx.ErrNoRows) {
 		logger.Error("Failed to read runtime config", "key", runtimeConfigKey, "error", err)
@@ -60,7 +60,6 @@ func (s *UtilServer) GenerateRandomString(ctx context.Context, req *pb.GenerateR
 		}
 	}
 
-	// Generate random string (16 random bytes -> 32 hex characters)
 	b := make([]byte, 16)
 	_, err = rand.Read(b)
 	if err != nil {
@@ -71,7 +70,6 @@ func (s *UtilServer) GenerateRandomString(ctx context.Context, req *pb.GenerateR
 	randomStr := hex.EncodeToString(b)
 	logger.Info("Generated random string", "length", len(randomStr))
 
-	// Write updated LAST_RUN_TIMESTAMP back to the runtime config
 	now := time.Now().UTC().Format(time.RFC3339)
 	updatedVal := runtimeConfigValue{
 		Enabled:          true,

--- a/services/backend/internal/grpc/util_service_test.go
+++ b/services/backend/internal/grpc/util_service_test.go
@@ -60,7 +60,6 @@ func TestUtilServer_GenerateRandomString_Success(t *testing.T) {
 	require.NotNil(t, resp)
 	assert.Len(t, resp.RandomString, 32)
 
-	// Verify DB interactions
 	assert.Len(t, mockQuerier.GetRuntimeConfigByKeyCalls(), 1)
 	assert.Equal(t, "go_config_example", mockQuerier.GetRuntimeConfigByKeyCalls()[0].Key)
 	assert.Len(t, mockQuerier.UpsertRuntimeConfigValueCalls(), 1)
@@ -77,7 +76,6 @@ func TestUtilServer_GenerateRandomString_IsHex(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 
-	// Verify the string only contains valid hex characters
 	for _, c := range resp.RandomString {
 		assert.True(t, (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f'), "expected hex character, got %c", c)
 	}
@@ -94,12 +92,10 @@ func TestUtilServer_GenerateRandomString_Unique(t *testing.T) {
 	resp2, err := server.GenerateRandomString(ctx, &pb.GenerateRandomStringRequest{})
 	require.NoError(t, err)
 
-	// Two calls should produce different strings (extremely unlikely to collide)
 	assert.NotEqual(t, resp1.RandomString, resp2.RandomString)
 }
 
 func TestUtilServer_GenerateRandomString_NoExistingConfig(t *testing.T) {
-	// Simulate first run where no config exists yet
 	mockQuerier := &mocks.QuerierMock{
 		GetRuntimeConfigByKeyFunc: func(ctx context.Context, key string) (db.SourceRuntimeConfig, error) {
 			return db.SourceRuntimeConfig{}, pgx.ErrNoRows
@@ -126,8 +122,6 @@ func TestUtilServer_GenerateRandomString_NoExistingConfig(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 	assert.Len(t, resp.RandomString, 32)
-
-	// Should still write the config even on first run
 	assert.Len(t, mockQuerier.UpsertRuntimeConfigValueCalls(), 1)
 }
 
@@ -142,7 +136,6 @@ func TestUtilServer_GenerateRandomString_WritesUpdatedTimestamp(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 
-	// Verify the upserted value contains an updated timestamp
 	upsertCall := mockQuerier.UpsertRuntimeConfigValueCalls()[0]
 	var written map[string]interface{}
 	err = json.Unmarshal(upsertCall.Arg.Value, &written)

--- a/services/dagster/src/dagster_project/assets/exports/materialize_user_journal_features.py
+++ b/services/dagster/src/dagster_project/assets/exports/materialize_user_journal_features.py
@@ -19,48 +19,43 @@ def materialize_user_journal_features(
     with feast_store.get_store() as store:
         feature_view_name = "user_journal_summary_features"
 
-        # Try to get the feature view, apply if it doesn't exist.
-        # these exist in postgres under `feast.feature_views`
+        # Feature views are persisted in Postgres under `feast.feature_views`.
+        # If this is a fresh environment the view won't exist yet, so fall back
+        # to applying it from the repo-local definitions.
         try:
             fv = store.get_feature_view(feature_view_name)
             context.log.info(f"Found feature view: {fv.name}")
         except Exception:
-            # Feature view not found, need to apply it
             context.log.info(
                 f"Feature view '{feature_view_name}' not found, applying to registry..."
             )
 
-            # path fix to make sure we can apply the feature ddls
+            # The feast repo isn't on sys.path by default; temporarily add it so
+            # we can import the entity/feature-view definitions, then clean up.
             repo_path = Path(feast_store.repo_path)
             if str(repo_path) not in sys.path:
                 sys.path.insert(0, str(repo_path))
 
             try:
-                # Import entities and feature views
                 from entities import user_entity
                 from feature_views import user_journal_summary_fv
 
-                # Apply them to the registry
                 store.apply([user_entity, user_journal_summary_fv])
                 context.log.info("Feature views applied successfully")
 
-                # Now get the feature view
                 fv = store.get_feature_view(feature_view_name)
             except Exception as e:
-                # Remove from path if we added it
                 if str(repo_path) in sys.path:
                     sys.path.remove(str(repo_path))
                 raise ValueError(f"Failed to apply feature views: {e}") from e
             finally:
-                # Clean up sys.path
                 if str(repo_path) in sys.path:
                     sys.path.remove(str(repo_path))
 
-        # Log config for debugging
         context.log.info(f"Online store config: {store.config.online_store}")
         context.log.info(f"Offline store config: {store.config.offline_store}")
 
-        # Wide time range to capture all data
+        # Use a wide time range so we pick up historical rows on first run.
         start_date = datetime(2020, 1, 1, tzinfo=timezone.utc)
         end_date = datetime.now(timezone.utc)
 
@@ -68,7 +63,6 @@ def materialize_user_journal_features(
             f"Materializing {feature_view_name} from {start_date} to {end_date}"
         )
 
-        # Run materialization
         store.materialize(
             feature_views=[feature_view_name],
             start_date=start_date,

--- a/services/dagster/src/dagster_project/assets/ingestion/utils.py
+++ b/services/dagster/src/dagster_project/assets/ingestion/utils.py
@@ -67,14 +67,12 @@ def create_basic_metadata(
         "partition": MetadataValue.text(get_partition_date_str(context)),
     }
 
-    # Extract num_rows from DataFrame if not provided
     if num_rows is None and df is not None:
         num_rows = len(df)
 
     if num_rows is not None:
         metadata["num_rows"] = MetadataValue.int(num_rows)
 
-    # Extract date_range from DataFrame if not provided
     if date_range is None and df is not None and date_column in df.columns:
         date_range = extract_date_range(df, date_column)
 

--- a/services/dagster/src/dagster_project/dbt_config.py
+++ b/services/dagster/src/dagster_project/dbt_config.py
@@ -3,23 +3,15 @@ from pathlib import Path
 
 from dagster_dbt import DbtProject
 
-# Calculate path to dbt project
-# From /app/src/dagster_project/dbt_config.py:
-# Path(__file__) = /app/src/dagster_project/dbt_config.py
-# Path(__file__).parent = /app/src/dagster_project/
-# Path(__file__).parent.parent = /app/src/
-# Path(__file__).parent.parent.parent = /app/
-# So /app/dbt
+# In the container, this resolves to /app/dbt (three levels up from this file).
 DBT_PROJECT_DIR = Path(__file__).parent.parent.parent / "dbt"
-
-# 1. Define the specific path to your profiles directory
 DBT_PROFILES_DIR = DBT_PROJECT_DIR / "profiles"
 
-# Initialize dbt_project only if the directory exists
-# This allows tests to import the module without requiring the dbt project
+# Skip initialization when the dbt project isn't mounted (e.g. unit tests that
+# only import dagster_project). Tests can still import this module safely.
 if DBT_PROJECT_DIR.exists() and DBT_PROJECT_DIR.is_dir():
-    # 2. CRITICAL: Set the Environment Variable
-    # This tells 'prepare_if_dev' (and dbt globally) where to look
+    # DBT_PROFILES_DIR must be set in the environment for prepare_if_dev() and
+    # any subsequent dbt invocations to find the profiles file.
     os.environ["DBT_PROFILES_DIR"] = str(DBT_PROFILES_DIR)
 
     dbt_project = DbtProject(
@@ -29,6 +21,4 @@ if DBT_PROJECT_DIR.exists() and DBT_PROJECT_DIR.is_dir():
 
     dbt_project.prepare_if_dev()
 else:
-    # Set dbt_project to None if directory doesn't exist
-    # This allows tests to import the module without errors
     dbt_project = None

--- a/services/dagster/src/dagster_project/resources/slack.py
+++ b/services/dagster/src/dagster_project/resources/slack.py
@@ -59,15 +59,13 @@ class SlackResource(ConfigurableResource):
         response = requests.post(self.webhook_url, json=payload, timeout=10)
         response.raise_for_status()
 
-        # Slack webhooks return "ok" as plain text, not JSON
-        # Return a dict with the status for consistency
+        # Slack webhooks return plain "ok" (not JSON) on success; normalize the
+        # shape so callers always get a dict.
         if response.text.strip() == "ok":
             return {"ok": True, "text": response.text}
-        # Try to parse as JSON if it's not "ok"
         try:
             return response.json()
         except ValueError:
-            # If not JSON, return the text response
             return {"ok": True, "text": response.text}
 
     def _send_via_bot_token(self, message: str, channel: str | None) -> dict:
@@ -92,7 +90,6 @@ class SlackResource(ConfigurableResource):
         return result
 
 
-# Create default Slack resource instance
 slack_resource = SlackResource(
     webhook_url=EnvVar("SLACK_WEBHOOK_URL"),
     bot_token=EnvVar("SLACK_BOT_TOKEN"),

--- a/services/dagster/tests/integration/test_api_assets_integration.py
+++ b/services/dagster/tests/integration/test_api_assets_integration.py
@@ -17,10 +17,7 @@ from dagster_project.assets.ingestion.get_api_assets import (
 @pytest.mark.integration
 @pytest.mark.slow
 class TestIntegration:
-    """Integration tests that require external services."""
-
     def test_get_api_users_integration(self):
-        """Test get_api_users asset with real API call."""
         context = build_asset_context()
         try:
             result = get_api_users(context)
@@ -34,8 +31,6 @@ class TestIntegration:
         assert "email" in result[0]
 
     def test_users_in_postgres_integration(self, postgres_resource_with_cleanup):
-        """Test users_in_postgres asset with a real Postgres testcontainer."""
-        # Create test users
         test_users = [
             {
                 "id": 999,
@@ -47,11 +42,9 @@ class TestIntegration:
 
         context = build_asset_context()
 
-        # Execute the asset
         users_in_postgres(context, test_users, postgres_resource_with_cleanup)
 
-        # Verify data was stored
-        # Note: search_path is set in PostgresResource, so table is in the test schema
+        # search_path is set in PostgresResource, so table is in the test schema
         with (
             postgres_resource_with_cleanup.get_connection() as conn,
             conn.cursor() as cur,

--- a/services/dagster/tests/unit/assets/exports/test_unload_journals_to_s3.py
+++ b/services/dagster/tests/unit/assets/exports/test_unload_journals_to_s3.py
@@ -19,10 +19,7 @@ def _make_mock_postgres(df: pl.DataFrame) -> MagicMock:
 
 @pytest.mark.unit
 class TestUnloadJournalsToS3:
-    """Test the unload_journals_to_s3 asset."""
-
     def test_unload_journals_to_s3_success(self):
-        """Test successful unload of journals from Postgres."""
         expected_df = pl.DataFrame(
             {
                 "id": [1, 2, 3],
@@ -50,7 +47,6 @@ class TestUnloadJournalsToS3:
         assert list(result.columns) == ["id", "user_name", "amount", "date"]
 
     def test_unload_journals_to_s3_empty_result(self):
-        """Test handling of empty query result."""
         expected_df = pl.DataFrame(
             {
                 "id": [],
@@ -74,7 +70,6 @@ class TestUnloadJournalsToS3:
         assert len(result) == 0
 
     def test_unload_journals_to_s3_logs_info(self):
-        """Test that asset logs information about the dataframe."""
         expected_df = pl.DataFrame(
             {
                 "id": [1],

--- a/services/dagster/tests/unit/assets/ingestion/test_example_assets.py
+++ b/services/dagster/tests/unit/assets/ingestion/test_example_assets.py
@@ -8,10 +8,7 @@ from dagster_project.assets.ingestion.example_assets import hello_world_asset
 
 @pytest.mark.unit
 class TestHelloWorldAsset:
-    """Test the hello_world_asset."""
-
     def test_hello_world_asset_success(self):
-        """Test successful execution of hello_world_asset."""
         context = build_op_context()
 
         result = hello_world_asset(context)
@@ -19,11 +16,9 @@ class TestHelloWorldAsset:
         assert result is None
 
     def test_hello_world_asset_logs_message(self):
-        """Test that asset logs the hello world message."""
         context = build_op_context()
 
         hello_world_asset(context)
 
-        # Verify that logging occurred (context.log should have been called)
-        # Note: Direct log verification may not be possible, but we can verify execution
-        assert True  # Asset executed without error
+        # Direct log verification may not be possible; we only verify execution.
+        assert True

--- a/services/dagster/tests/unit/assets/ingestion/test_get_api_assets.py
+++ b/services/dagster/tests/unit/assets/ingestion/test_get_api_assets.py
@@ -14,10 +14,7 @@ from dagster_project.assets.ingestion.get_api_assets import (
 
 @pytest.mark.unit
 class TestApiUsers:
-    """Test the get_api_users asset."""
-
     def test_get_api_users_success(self):
-        """Test successful API fetch."""
         mock_users = [
             {
                 "id": 1,
@@ -44,7 +41,6 @@ class TestApiUsers:
             )
 
     def test_get_api_users_http_error(self):
-        """Test handling of HTTP errors."""
         with patch(
             "dagster_project.assets.ingestion.get_api_assets.requests.get"
         ) as mock_get:
@@ -60,10 +56,7 @@ class TestApiUsers:
 
 @pytest.mark.unit
 class TestUsersInPostgres:
-    """Test the users_in_postgres asset."""
-
     def test_users_in_postgres_success(self, mock_postgres_resource, asset_context):
-        """Test successful storage of users in Postgres."""
         mock_users = [
             {
                 "id": 1,
@@ -79,7 +72,6 @@ class TestUsersInPostgres:
             },
         ]
 
-        # Execute the asset with resources provided via context
         # Wrap the mock in a ResourceDefinition so Dagster accepts it
         def resource_fn(_context):
             return mock_postgres_resource
@@ -88,11 +80,9 @@ class TestUsersInPostgres:
         context = build_op_context(resources={"postgres_conn": postgres_resource_def})
         users_in_postgres(context, mock_users)
 
-        # Verify database interactions
         mock_postgres_resource.get_connection.assert_called_once()
         mock_cursor = mock_postgres_resource.get_connection.return_value.__enter__.return_value.cursor.return_value.__enter__.return_value
 
-        # Check that CREATE TABLE was called
         create_table_calls = [
             call
             for call in mock_cursor.execute.call_args_list
@@ -100,7 +90,6 @@ class TestUsersInPostgres:
         ]
         assert len(create_table_calls) > 0
 
-        # Check that INSERT statements were called for each user
         insert_calls = [
             call
             for call in mock_cursor.execute.call_args_list
@@ -108,15 +97,12 @@ class TestUsersInPostgres:
         ]
         assert len(insert_calls) == len(mock_users)
 
-        # Verify commit was called
         mock_conn = (
             mock_postgres_resource.get_connection.return_value.__enter__.return_value
         )
         mock_conn.commit.assert_called_once()
 
     def test_users_in_postgres_empty_list(self, mock_postgres_resource, asset_context):
-        """Test handling of empty user list."""
-
         def resource_fn(_context):
             return mock_postgres_resource
 

--- a/services/dagster/tests/unit/assets/ingestion/test_get_game_types_from_api.py
+++ b/services/dagster/tests/unit/assets/ingestion/test_get_game_types_from_api.py
@@ -13,10 +13,7 @@ from dagster_project.assets.ingestion.get_game_types_from_api import (
 
 @pytest.mark.unit
 class TestGetGameTypesFromApi:
-    """Test the get_game_types_from_api asset."""
-
     def test_get_game_types_from_api_success(self):
-        """Test successful fetch of game types from API."""
         mock_data = [
             {"id": 1, "name": "Regular Season"},
             {"id": 2, "name": "Playoffs"},
@@ -43,7 +40,6 @@ class TestGetGameTypesFromApi:
         mock_response.raise_for_status.assert_called_once()
 
     def test_get_game_types_from_api_http_error(self):
-        """Test handling of HTTP errors."""
         mock_session = MagicMock()
         mock_response = MagicMock()
         mock_response.raise_for_status.side_effect = requests.HTTPError("API Error")
@@ -58,7 +54,6 @@ class TestGetGameTypesFromApi:
             get_game_types_from_api(context)
 
     def test_get_game_types_from_api_json_decode_error(self):
-        """Test handling of JSON decode errors."""
         mock_session = MagicMock()
         mock_response = MagicMock()
         mock_response.status_code = 200
@@ -76,6 +71,3 @@ class TestGetGameTypesFromApi:
 
         with pytest.raises(requests.exceptions.JSONDecodeError):
             get_game_types_from_api(context)
-
-        # Verify error logging was attempted
-        assert True  # Asset attempted to log error before raising

--- a/services/dagster/tests/unit/assets/ingestion/test_get_sales_data.py
+++ b/services/dagster/tests/unit/assets/ingestion/test_get_sales_data.py
@@ -11,10 +11,7 @@ from dagster_project.assets.ingestion.get_sales_data import sales_data
 
 @pytest.mark.unit
 class TestSalesData:
-    """Test the sales_data asset."""
-
     def test_sales_data_success(self):
-        """Test successful generation of sales data DataFrame."""
         context = build_op_context(partition_key="2025-12-18")
 
         result = sales_data(context)
@@ -26,27 +23,22 @@ class TestSalesData:
         assert "id" in result.columns
         assert "total_sales" in result.columns
         assert "date" in result.columns
-        # Check that date matches the partition date
         partition_date = date(2025, 12, 18)
         assert all(result["date"] == partition_date)
 
     def test_sales_data_has_correct_structure(self):
-        """Test that sales_data generates correct DataFrame structure."""
         context = build_op_context(partition_key="2025-12-18")
 
         result = sales_data(context)
 
-        # Verify column types
         # IDs are UUID strings, not integers
         assert result["id"].dtype == pl.Utf8
         assert result["total_sales"].dtype == pl.Int64
         assert result["date"].dtype == pl.Date
 
-        # Verify IDs are non-null UUID strings
         assert result["id"].null_count() == 0
         # UUIDs are 36 characters long (with hyphens)
         assert all(result["id"].str.len_chars() == 36)
 
-        # Verify sales values are within expected range
         assert result["total_sales"].min() >= 10
         assert result["total_sales"].max() <= 100

--- a/services/dagster/tests/unit/assets/ingestion/test_materialization.py
+++ b/services/dagster/tests/unit/assets/ingestion/test_materialization.py
@@ -14,10 +14,7 @@ from dagster_project.resources import PostgresResource
 
 @pytest.mark.unit
 class TestMaterialization:
-    """Test asset materialization with mocked resources."""
-
     def test_materialize_get_api_users(self):
-        """Test materializing get_api_users asset."""
         mock_users = [
             {
                 "id": 1,
@@ -44,7 +41,6 @@ class TestMaterialization:
                 )
 
     def test_materialize_with_mocked_postgres(self):
-        """Test materializing users_in_postgres with mocked database."""
         mock_users = [
             {
                 "id": 1,
@@ -54,7 +50,6 @@ class TestMaterialization:
             }
         ]
 
-        # Mock the API call
         with patch(
             "dagster_project.assets.ingestion.get_api_assets.requests.get"
         ) as mock_get:
@@ -68,16 +63,14 @@ class TestMaterialization:
             mock_cursor = MagicMock()
             mock_conn.cursor.return_value.__enter__.return_value = mock_cursor
 
-            # Patch psycopg2.connect to return our mock connection
             with patch(
                 "dagster_project.resources.postgres.psycopg2.connect",
                 return_value=mock_conn,
             ):
-                # Create a real PostgresResource instance
                 mock_postgres = PostgresResource()
 
                 with instance_for_test() as instance:
-                    # Materialize both assets - ConfigurableResource instances can be passed directly
+                    # ConfigurableResource instances can be passed directly to materialize
                     result = materialize(
                         [get_api_users, users_in_postgres],
                         instance=instance,

--- a/services/dagster/tests/unit/resources/test_google_sheets.py
+++ b/services/dagster/tests/unit/resources/test_google_sheets.py
@@ -12,16 +12,12 @@ from dagster_project.resources.google_sheets import GoogleSheetsResource
 
 @pytest.mark.unit
 class TestGoogleSheetsResource:
-    """Test the GoogleSheetsResource."""
-
     def test_google_sheets_resource_initialization_defaults(self):
-        """Test resource initialization with defaults."""
         resource = GoogleSheetsResource()
         assert resource.sheet_url == "PLACEHOLDER_SHEET_URL"
         assert resource.credentials_json_b64 == "PLACEHOLDER_GCP_CREDENTIALS_JSON_B64"
 
     def test_google_sheets_resource_custom_config(self):
-        """Test resource initialization with custom config."""
         test_url = "https://docs.google.com/spreadsheets/d/test123"
         test_creds_b64 = base64.b64encode(b'{"type": "service_account"}').decode()
 
@@ -33,7 +29,6 @@ class TestGoogleSheetsResource:
         assert resource.credentials_json_b64 == test_creds_b64
 
     def test_get_client_raises_error_with_placeholder_credentials(self):
-        """Test get_client raises error when credentials are placeholder."""
         resource = GoogleSheetsResource()
 
         with pytest.raises(
@@ -47,8 +42,6 @@ class TestGoogleSheetsResource:
         "dagster_project.resources.google_sheets.Credentials.from_service_account_info"
     )
     def test_get_client_success(self, mock_credentials, mock_authorize):
-        """Test get_client successfully creates authenticated client."""
-        # Create valid base64-encoded credentials
         creds_dict = {
             "type": "service_account",
             "project_id": "test-project",
@@ -74,7 +67,6 @@ class TestGoogleSheetsResource:
 
         assert client == mock_client
         mock_credentials.assert_called_once()
-        # Verify credentials were decoded and parsed correctly
         call_args = mock_credentials.call_args[0][0]
         assert call_args == creds_dict
         assert mock_credentials.call_args[1]["scopes"] == [
@@ -87,7 +79,6 @@ class TestGoogleSheetsResource:
         "dagster_project.resources.google_sheets.Credentials.from_service_account_info"
     )
     def test_get_client_invalid_base64(self, mock_credentials, mock_authorize):
-        """Test get_client raises error with invalid base64 credentials."""
         resource = GoogleSheetsResource(
             sheet_url="https://docs.google.com/spreadsheets/d/test123",
             credentials_json_b64="invalid_base64!!!",
@@ -101,7 +92,6 @@ class TestGoogleSheetsResource:
         "dagster_project.resources.google_sheets.Credentials.from_service_account_info"
     )
     def test_get_client_invalid_json(self, mock_credentials, mock_authorize):
-        """Test get_client raises error with invalid JSON in credentials."""
         invalid_json_b64 = base64.b64encode(b"not valid json").decode()
 
         resource = GoogleSheetsResource(
@@ -117,7 +107,6 @@ class TestGoogleSheetsResource:
         "dagster_project.resources.google_sheets.Credentials.from_service_account_info"
     )
     def test_get_sheet_success(self, mock_credentials, mock_authorize):
-        """Test get_sheet successfully opens spreadsheet."""
         creds_dict = {
             "type": "service_account",
             "project_id": "test-project",
@@ -151,7 +140,6 @@ class TestGoogleSheetsResource:
         "dagster_project.resources.google_sheets.Credentials.from_service_account_info"
     )
     def test_get_sheet_calls_get_client(self, mock_credentials, mock_authorize):
-        """Test get_sheet calls get_client to authenticate."""
         creds_dict = {
             "type": "service_account",
             "project_id": "test-project",
@@ -175,16 +163,12 @@ class TestGoogleSheetsResource:
 
         resource.get_sheet()
 
-        # Verify get_client was called (via authorize)
         mock_authorize.assert_called_once()
-        # Verify get_sheet was called (via open_by_url)
         mock_client.open_by_url.assert_called_once()
 
 
 @pytest.mark.unit
 class TestGoogleSheetsResourceHelpers:
-    """Test the reusable helpers on GoogleSheetsResource."""
-
     def _resource(self) -> GoogleSheetsResource:
         return GoogleSheetsResource(
             sheet_url="https://docs.google.com/spreadsheets/d/test123",

--- a/services/dagster/tests/unit/resources/test_s3.py
+++ b/services/dagster/tests/unit/resources/test_s3.py
@@ -12,8 +12,6 @@ from dagster_project.resources import S3Resource
 
 @pytest.mark.unit
 class TestS3Resource:
-    """Test the S3Resource."""
-
     def _resource(self, **overrides) -> S3Resource:
         defaults = {"bucket": "test-bucket", "region": "us-east-1", "endpoint_url": ""}
         return S3Resource(**(defaults | overrides))
@@ -59,7 +57,6 @@ class TestS3Resource:
         assert call_kwargs["Bucket"] == "test-bucket"
         assert call_kwargs["Key"] == key
 
-        # Verify body is valid parquet
         written_df = pl.read_parquet(BytesIO(call_kwargs["Body"]))
         assert written_df.shape == (2, 2)
         assert written_df["id"].to_list() == [1, 2]

--- a/services/dagster/tests/unit/resources/test_slack.py
+++ b/services/dagster/tests/unit/resources/test_slack.py
@@ -10,17 +10,13 @@ from dagster_project.resources.slack import SlackResource
 
 @pytest.mark.unit
 class TestSlackResource:
-    """Test the SlackResource."""
-
     def test_slack_resource_initialization_defaults(self):
-        """Test resource initialization with defaults."""
         resource = SlackResource()
         assert resource.webhook_url == ""
         assert resource.bot_token == ""
         assert resource.default_channel == ""
 
     def test_slack_resource_custom_config(self):
-        """Test resource initialization with custom config."""
         resource = SlackResource(
             webhook_url="https://hooks.slack.com/test",
             bot_token="xoxb-test-token",
@@ -32,7 +28,6 @@ class TestSlackResource:
 
     @patch("dagster_project.resources.slack.requests.post")
     def test_send_message_via_webhook_success(self, mock_post):
-        """Test sending message via webhook successfully."""
         mock_response = MagicMock()
         mock_response.text = "ok"
         mock_response.raise_for_status.return_value = None
@@ -50,7 +45,6 @@ class TestSlackResource:
 
     @patch("dagster_project.resources.slack.requests.post")
     def test_send_message_via_webhook_with_channel(self, mock_post):
-        """Test sending message via webhook with channel override."""
         mock_response = MagicMock()
         mock_response.text = "ok"
         mock_response.raise_for_status.return_value = None
@@ -68,7 +62,6 @@ class TestSlackResource:
 
     @patch("dagster_project.resources.slack.requests.post")
     def test_send_message_via_webhook_with_username_and_emoji(self, mock_post):
-        """Test sending message via webhook with username and emoji."""
         mock_response = MagicMock()
         mock_response.text = "ok"
         mock_response.raise_for_status.return_value = None
@@ -94,7 +87,6 @@ class TestSlackResource:
 
     @patch("dagster_project.resources.slack.requests.post")
     def test_send_message_via_webhook_uses_default_channel(self, mock_post):
-        """Test sending message via webhook uses default_channel when channel not provided."""
         mock_response = MagicMock()
         mock_response.text = "ok"
         mock_response.raise_for_status.return_value = None
@@ -115,7 +107,6 @@ class TestSlackResource:
 
     @patch("dagster_project.resources.slack.requests.post")
     def test_send_message_via_webhook_json_response(self, mock_post):
-        """Test sending message via webhook with JSON response."""
         mock_response = MagicMock()
         mock_response.text = '{"ok": true, "message": "sent"}'
         mock_response.json.return_value = {"ok": True, "message": "sent"}
@@ -129,7 +120,6 @@ class TestSlackResource:
 
     @patch("dagster_project.resources.slack.requests.post")
     def test_send_message_via_webhook_non_json_response(self, mock_post):
-        """Test sending message via webhook with non-JSON, non-ok response."""
         mock_response = MagicMock()
         mock_response.text = "some other response"
         mock_response.json.side_effect = ValueError("Not JSON")
@@ -143,7 +133,6 @@ class TestSlackResource:
 
     @patch("dagster_project.resources.slack.requests.post")
     def test_send_message_via_webhook_http_error(self, mock_post):
-        """Test sending message via webhook raises HTTP error."""
         mock_response = MagicMock()
         mock_response.raise_for_status.side_effect = requests.HTTPError("HTTP Error")
         mock_post.return_value = mock_response
@@ -155,7 +144,6 @@ class TestSlackResource:
 
     @patch("dagster_project.resources.slack.requests.post")
     def test_send_message_via_bot_token_success(self, mock_post):
-        """Test sending message via bot token successfully."""
         mock_response = MagicMock()
         mock_response.json.return_value = {"ok": True, "ts": "1234567890.123456"}
         mock_response.raise_for_status.return_value = None
@@ -177,7 +165,6 @@ class TestSlackResource:
 
     @patch("dagster_project.resources.slack.requests.post")
     def test_send_message_via_bot_token_uses_default_channel(self, mock_post):
-        """Test sending message via bot token uses default_channel when channel not provided."""
         mock_response = MagicMock()
         mock_response.json.return_value = {"ok": True}
         mock_response.raise_for_status.return_value = None
@@ -202,7 +189,6 @@ class TestSlackResource:
 
     @patch("dagster_project.resources.slack.requests.post")
     def test_send_message_via_bot_token_api_error(self, mock_post):
-        """Test sending message via bot token raises error when API returns error."""
         mock_response = MagicMock()
         mock_response.json.return_value = {"ok": False, "error": "channel_not_found"}
         mock_response.raise_for_status.return_value = None
@@ -214,7 +200,6 @@ class TestSlackResource:
             resource.send_message("Test message", channel="#test-channel")
 
     def test_send_message_via_bot_token_no_channel(self):
-        """Test sending message via bot token raises error when channel is missing."""
         resource = SlackResource(bot_token="xoxb-test-token")
 
         with pytest.raises(
@@ -223,7 +208,6 @@ class TestSlackResource:
             resource.send_message("Test message")
 
     def test_send_message_no_config(self):
-        """Test sending message raises error when neither webhook_url nor bot_token is configured."""
         resource = SlackResource()
 
         with pytest.raises(
@@ -233,7 +217,6 @@ class TestSlackResource:
 
     @patch("dagster_project.resources.slack.requests.post")
     def test_send_message_webhook_takes_precedence(self, mock_post):
-        """Test that webhook_url takes precedence over bot_token when both are set."""
         mock_response = MagicMock()
         mock_response.text = "ok"
         mock_response.raise_for_status.return_value = None
@@ -244,10 +227,8 @@ class TestSlackResource:
             bot_token="xoxb-test-token",
         )
 
-        # Should use webhook, not bot token
         result = resource.send_message("Test message", channel="#test-channel")
 
-        # Verify webhook URL was called, not bot token API
         mock_post.assert_called_once_with(
             "https://hooks.slack.com/test",
             json={"text": "Test message", "channel": "#test-channel"},

--- a/services/django/core/admin.py
+++ b/services/django/core/admin.py
@@ -43,7 +43,6 @@ class LotusAdminSite(UnfoldAdminSite):
         return _has_admin_access(request.user)
 
 
-# Create custom admin site instance
 admin_site = LotusAdminSite(name="lotus_admin")
 
 ACTIVE_ML_MODEL_ALLOWED_GROUPS = ("product", "ml_ops")
@@ -129,7 +128,7 @@ class ActiveMLModelAdmin(ModelAdmin):
         (None, {"fields": ("id", "ml_model", "is_enabled")}),
         ("Timestamps", {"fields": ("created_at", "modified_at")}),
     )
-    list_editable = ("is_enabled",)  # Allow quick editing of enabled status from list view
+    list_editable = ("is_enabled",)
 
     def has_add_permission(self, request):
         """Only allow Admin role or product/ml_ops groups to add."""
@@ -152,20 +151,18 @@ class ActiveMLModelAdmin(ModelAdmin):
         return has_ml_model_permission(request.user)
 
 
-# Unregister User and Group from default admin site
 admin.site.unregister(User)
 admin.site.unregister(Group)
 
-# Unregister Waffle models from default admin site (they auto-register there)
+# Waffle auto-registers on the default site; move its models to our custom one.
 admin.site.unregister(Flag)
 admin.site.unregister(Switch)
 admin.site.unregister(Sample)
 
 
-# Register User and Group with custom admin site
 @admin.register(User, site=admin_site)
 class UserAdmin(BaseUserAdmin, ModelAdmin):
-    # Forms loaded from `unfold.forms` for proper Unfold styling
+    # Use Unfold's forms so the auth UI matches the rest of the custom admin.
     form = UserChangeForm
     add_form = UserCreationForm
     change_password_form = AdminPasswordChangeForm
@@ -451,7 +448,6 @@ class StakeholderPromptResponseAdmin(ModelAdmin):
         return False
 
 
-# Register Waffle models with custom admin site
 @admin.register(Flag, site=admin_site)
 class WaffleFlagAdmin(ModelAdmin):
     list_display = ("name", "everyone", "superusers", "staff", "note", "created", "modified")

--- a/services/django/core/backends.py
+++ b/services/django/core/backends.py
@@ -19,25 +19,19 @@ class LotusUserBackend(BaseBackend):
             username = kwargs.get("email")
 
         try:
-            # Try to find user by email
             lotus_user = LotusUser.objects.get(email=username)
 
-            # For OAuth users, we can't verify password here
-            # In production, you'd want to integrate with your OAuth flow
+            # OAuth users have no local password; trust the OAuth flow upstream
+            # and mirror them into Django auth so the admin session works.
             if lotus_user.password is None and lotus_user.oauth_provider:
-                # OAuth user - create Django user if doesn't exist
                 django_user, _ = DjangoUser.objects.get_or_create(
                     username=lotus_user.email, defaults={"email": lotus_user.email}
                 )
                 return django_user
 
-            # For password-based users, verify password
-            # Note: You'll need to implement password hashing verification
-            # based on your password hashing scheme (salt + password)
+            # TODO: verify password against the project's salt+hash scheme before
+            # returning a Django user. Currently accepts any non-empty password.
             if password and lotus_user.password:
-                # TODO: Implement password verification based on your hashing scheme
-                # For now, this is a placeholder
-                # You'll need to hash the password with the salt and compare
                 django_user, _ = DjangoUser.objects.get_or_create(
                     username=lotus_user.email, defaults={"email": lotus_user.email}
                 )

--- a/services/django/core/management/commands/sync_django_users.py
+++ b/services/django/core/management/commands/sync_django_users.py
@@ -32,7 +32,6 @@ class Command(BaseCommand):
                 django_user = DjangoUser.objects.get(username=lotus_user.email)
                 needs_update = False
 
-                # Check if email needs updating
                 if django_user.email != lotus_user.email:
                     needs_update = True
                     if not dry_run:

--- a/services/django/core/middleware.py
+++ b/services/django/core/middleware.py
@@ -13,7 +13,6 @@ def _has_admin_access(user):
     if not user.is_authenticated:
         return False
 
-    # Cache key based on user ID and email
     cache_key = f"admin_access_{user.id}_{user.email}"
     cached_result = cache.get(cache_key)
     if cached_result is not None:
@@ -22,21 +21,18 @@ def _has_admin_access(user):
     try:
         from .models import User as LotusUser
 
-        # Check if user has Admin role
         db_user = LotusUser.objects.filter(email=user.email).first()
         has_admin_role = db_user and db_user.role == settings.ADMIN_ROLE_NAME
 
-        # Check if user is in allowed groups (configurable via settings)
         allowed_groups = getattr(settings, "ADMIN_ALLOWED_GROUPS", ["product_manager"])
         is_in_allowed_group = user.groups.filter(name__in=allowed_groups).exists()
 
         has_access = has_admin_role or is_in_allowed_group
 
-        # Cache for 5 minutes to reduce database queries
         cache.set(cache_key, has_access, 300)
         return has_access
     except Exception:
-        # On error, deny access for safety
+        # Fail closed so a lookup error cannot grant admin access.
         return False
 
 
@@ -50,38 +46,29 @@ class AdminOnlyMiddleware:
         self.get_response = get_response
 
     def __call__(self, request):
-        # Check if this is an admin URL (either default Django admin or custom admin site)
-        # Custom admin site is mounted at root, so check for /core/ paths (app name)
+        # The custom admin site is mounted at /core/; the stock Django admin at /admin/.
         is_admin_path = request.path.startswith("/admin/") or request.path.startswith("/core/")
 
         if not is_admin_path:
             response = self.get_response(request)
             return response
 
-        # Skip authentication check for login/logout pages
         login_paths = ["/admin/login/", "/admin/logout/", "/admin/", "/login/", "/logout/", "/"]
         if request.path in login_paths:
             response = self.get_response(request)
             return response
 
-        # Check if user is authenticated
         if not request.user.is_authenticated:
-            # Allow access to login page
             if request.path in ["/admin/login/", "/login/"]:
                 response = self.get_response(request)
                 return response
-            # Redirect to login for other admin pages
-            # Use the appropriate login URL based on path
             login_url = "/login/" if request.path.startswith("/core/") else "/admin/login/"
             return redirect(f"{login_url}?next={request.path}")
 
-        # Check if user has admin access (cached)
         if _has_admin_access(request.user):
-            # User has access, allow
             response = self.get_response(request)
             return response
         else:
-            # User does not have access, deny
             logout(request)
             return HttpResponseForbidden(
                 "<h1>403 Forbidden</h1><p>Admin or Product Manager access required. Only users with Admin role or Product Manager group membership can access this interface.</p>"

--- a/services/django/core/signals.py
+++ b/services/django/core/signals.py
@@ -33,22 +33,20 @@ def sync_django_user(sender, instance, created, **kwargs):
     - Admin role users get is_staff=True and is_superuser=True
     - Other users get basic Django User (created for consistency)
     """
-    # Get old email if this was an update
     old_email = _old_email_cache.pop(instance.pk, None) if not created else None
 
-    # Determine lookup email: use old email if email changed, otherwise use current email
+    # Look up the existing Django User by its prior email so we can carry the row
+    # through an email change; the username stays pinned to the original address.
     lookup_email = old_email if old_email and old_email != instance.email else instance.email
 
     try:
         django_user = DjangoUser.objects.get(username=lookup_email)
     except DjangoUser.DoesNotExist:
-        # Create new Django User
         django_user = DjangoUser.objects.create(
             username=instance.email,
             email=instance.email,
         )
 
-    # Update email if it changed (username stays as original email)
     if django_user.email != instance.email:
         django_user.email = instance.email
         django_user.save()

--- a/services/django/tests/test_management_commands.py
+++ b/services/django/tests/test_management_commands.py
@@ -26,22 +26,19 @@ class TestCreateAdminUserCommand:
 
     def test_create_admin_user_success(self):
         """Creating admin user when LotusUser exists with Admin role should succeed."""
-        # Use unique email to avoid conflicts with conftest admin_user fixture
+        # Unique email avoids collision with the conftest admin_user fixture.
         email = "cmd_admin@test.com"
 
-        # Create LotusUser with Admin role (signal will create Django User with admin privileges)
         LotusUser.objects.create(
             email=email,
             role="Admin",
             timezone="UTC",
         )
 
-        # Get Django User created by signal and verify it has admin privileges
         django_user = DjangoUser.objects.get(username=email)
         assert django_user.is_staff is True
         assert django_user.is_superuser is True
 
-        # Run command to set password (user already exists with correct privileges)
         out = StringIO()
         call_command(
             "create_admin_user",
@@ -50,35 +47,29 @@ class TestCreateAdminUserCommand:
             stdout=out,
         )
 
-        # Verify Django User password was set
         django_user.refresh_from_db()
         assert django_user.check_password("testpass123")
         assert django_user.is_staff is True
         assert django_user.is_superuser is True
 
-        # Verify output
         output = out.getvalue()
         assert "Successfully created/updated admin user" in output
         assert email in output
 
     def test_create_admin_user_updates_existing_django_user(self):
         """Updating existing Django User should work."""
-        # Use unique email to avoid conflicts
         email = "cmd_update@test.com"
 
-        # Create LotusUser with Admin role (signal will create Django User)
         LotusUser.objects.create(
             email=email,
             role="Admin",
             timezone="UTC",
         )
 
-        # Get Django User created by signal and set password
         django_user = DjangoUser.objects.get(username=email)
         django_user.set_password("oldpassword")
         django_user.save()
 
-        # Run command
         out = StringIO()
         call_command(
             "create_admin_user",
@@ -87,12 +78,10 @@ class TestCreateAdminUserCommand:
             stdout=out,
         )
 
-        # Verify Django User was updated
         django_user.refresh_from_db()
         assert django_user.check_password("newpass123")
         assert django_user.email == email
 
-        # Verify output mentions update
         output = out.getvalue()
         assert "Updated existing Django user" in output or "Successfully created/updated" in output
 
@@ -107,23 +96,21 @@ class TestCreateAdminUserCommand:
             stdout=out,
         )
 
-        # Verify Django User was not created
         assert not DjangoUser.objects.filter(username="nonexistent@test.com").exists()
 
-        # Verify error message
         output = out.getvalue()
         assert "does not exist in the users table" in output
 
     def test_create_admin_user_fails_when_lotus_user_not_admin(self):
         """Command should fail when LotusUser exists but doesn't have Admin role."""
-        # Create LotusUser with Consumer role (signal will create Django User)
         LotusUser.objects.create(
             email="consumer@test.com",
             role="Consumer",
             timezone="UTC",
         )
 
-        # Delete Django User created by signal - command should not recreate it
+        # Delete the Django User auto-created by the signal so we can verify the
+        # command does not recreate it when the Lotus user is not an Admin.
         DjangoUser.objects.filter(username="consumer@test.com").delete()
 
         out = StringIO()
@@ -135,11 +122,8 @@ class TestCreateAdminUserCommand:
             stdout=out,
         )
 
-        # Verify Django User was not created by command (signal would create it, but we deleted it)
-        # The command should fail before creating a user
         assert not DjangoUser.objects.filter(username="consumer@test.com").exists()
 
-        # Verify error message
         output = out.getvalue()
         assert "does not have Admin role" in output
         assert "Consumer" in output
@@ -151,11 +135,10 @@ class TestSyncDjangoUsersCommand:
 
     def test_sync_django_users_creates_new_users(self):
         """Command should create Django Users for Lotus Users that don't have Django Users."""
-        # Create LotusUsers (signals will create Django Users)
         LotusUser.objects.create(email="sync_user1@test.com", role="Consumer", timezone="UTC")
         LotusUser.objects.create(email="sync_admin1@test.com", role="Admin", timezone="UTC")
 
-        # Delete Django Users created by signals to test command creation
+        # Remove the auto-created Django Users so the sync command has work to do.
         DjangoUser.objects.filter(
             username__in=["sync_user1@test.com", "sync_admin1@test.com"]
         ).delete()
@@ -163,7 +146,6 @@ class TestSyncDjangoUsersCommand:
         out = StringIO()
         call_command("sync_django_users", stdout=out)
 
-        # Verify Django Users were created
         user1 = DjangoUser.objects.get(username="sync_user1@test.com")
         assert user1.email == "sync_user1@test.com"
         assert user1.is_staff is False
@@ -174,7 +156,6 @@ class TestSyncDjangoUsersCommand:
         assert admin1.is_staff is True
         assert admin1.is_superuser is True
 
-        # Verify output
         output = out.getvalue()
         assert "Created Django User for sync_user1@test.com" in output
         assert "Created Django User for sync_admin1@test.com" in output
@@ -182,24 +163,21 @@ class TestSyncDjangoUsersCommand:
 
     def test_sync_django_users_updates_existing_users(self):
         """Command should update Django Users when LotusUser changes."""
-        # Create LotusUser (signal will create Django User)
         lotus_user = LotusUser.objects.create(
             email="user@test.com",
             role="Consumer",
             timezone="UTC",
         )
 
-        # Get Django User created by signal and set wrong permissions
         django_user = DjangoUser.objects.get(username="user@test.com")
         django_user.is_staff = True
         django_user.is_superuser = True
         django_user.save()
 
-        # Update LotusUser role to Admin (signal will update Django User, but we test command too)
         lotus_user.role = "Admin"
         lotus_user.save()
 
-        # Reset permissions to test command update
+        # Reset permissions so the sync command has an update to apply.
         django_user.is_staff = False
         django_user.is_superuser = False
         django_user.save()
@@ -207,57 +185,45 @@ class TestSyncDjangoUsersCommand:
         out = StringIO()
         call_command("sync_django_users", stdout=out)
 
-        # Verify Django User was updated
         django_user.refresh_from_db()
         assert django_user.is_staff is True
         assert django_user.is_superuser is True
 
-        # Verify output
         output = out.getvalue()
         assert "Updated Django User for user@test.com" in output
         assert "1 updated" in output
 
     def test_sync_django_users_updates_email(self):
         """Command should update Django User email when LotusUser email changes."""
-        # Note: The sync command has a limitation - it looks up Django Users by
-        # username=lotus_user.email, but when email changes, the username stays as the old email.
-        # So this test verifies the command behavior with the current implementation.
-
-        # Create LotusUser (signal will create Django User)
+        # The sync command looks up Django Users by username=lotus_user.email. When a
+        # LotusUser email changes, the signal updates Django User.email but not the
+        # username, so the sync command can no longer locate that row. This test
+        # pins down that behavior: the email change is persisted by the signal and
+        # sync_django_users leaves the existing record untouched rather than
+        # attempting (and failing) to recreate it.
         lotus_user = LotusUser.objects.create(
             email="original@test.com",
             role="Consumer",
             timezone="UTC",
         )
 
-        # Get Django User created by signal
         django_user = DjangoUser.objects.get(username="original@test.com")
-        # Update LotusUser email (signal will update Django User email)
         lotus_user.email = "updated@test.com"
         lotus_user.save()
 
-        # Verify signal updated the email
         django_user.refresh_from_db()
         assert django_user.email == "updated@test.com"
-        # Username should stay as original email
         assert django_user.username == "original@test.com"
 
-        # The sync command looks up by username=updated@test.com, which won't find this user
-        # So it won't update it. This is a limitation of the current sync command implementation.
-        # For now, we'll test that the signal handles it correctly.
         out = StringIO()
         call_command("sync_django_users", stdout=out)
 
-        # The sync command won't find the user because it looks for username="updated@test.com"
-        # but the username is "original@test.com". So it will try to create a new user,
-        # which will fail due to unique constraint on email. Let's verify the user still exists.
         django_user.refresh_from_db()
         assert django_user.email == "updated@test.com"
         assert django_user.username == "original@test.com"
 
     def test_sync_django_users_skips_already_synced_users(self):
         """Command should skip users that are already in sync."""
-        # Create LotusUser (signal will create Django User that's already in sync)
         LotusUser.objects.create(
             email="sync_skipped@test.com",
             role="Consumer",
@@ -267,68 +233,56 @@ class TestSyncDjangoUsersCommand:
         out = StringIO()
         call_command("sync_django_users", stdout=out)
 
-        # Verify output shows skipped
         output = out.getvalue()
         assert "Skipped sync_skipped@test.com (already in sync)" in output
         assert "skipped" in output.lower()
 
     def test_sync_django_users_dry_run(self):
         """Dry run should show what would be done without making changes."""
-        # Create LotusUser (signal will create Django User)
         LotusUser.objects.create(
             email="dryrun@test.com",
             role="Admin",
             timezone="UTC",
         )
 
-        # Delete Django User created by signal - dry run should show it would be created
         DjangoUser.objects.filter(username="dryrun@test.com").delete()
 
         out = StringIO()
         call_command("sync_django_users", "--dry-run", stdout=out)
 
-        # Verify Django User was NOT created by command (signal would create it, but we deleted it)
         assert not DjangoUser.objects.filter(username="dryrun@test.com").exists()
 
-        # Verify output shows dry run
         output = out.getvalue()
         assert "DRY RUN - No changes made" in output
         assert "Created Django User for dryrun@test.com" in output
 
     def test_sync_django_users_mixed_scenarios(self):
         """Command should handle mix of creates, updates, and skips."""
-        # Create LotusUsers (signals will create Django Users)
         LotusUser.objects.create(email="sync_new@test.com", role="Consumer", timezone="UTC")
         LotusUser.objects.create(email="sync_update@test.com", role="Consumer", timezone="UTC")
         LotusUser.objects.create(email="sync_skip@test.com", role="Consumer", timezone="UTC")
 
-        # Delete Django User for "new" to test creation
         DjangoUser.objects.filter(username="sync_new@test.com").delete()
 
-        # Get Django User that needs updating and set wrong permissions
+        # Put this user out of sync so the command must update it.
         django_user = DjangoUser.objects.get(username="sync_update@test.com")
-        django_user.is_staff = True  # Wrong - should be False
-        django_user.is_superuser = True  # Wrong - should be False
+        django_user.is_staff = True
+        django_user.is_superuser = True
         django_user.save()
-
-        # Django User for "skip" is already in sync (created by signal)
 
         out = StringIO()
         call_command("sync_django_users", stdout=out)
 
-        # Verify results
         assert DjangoUser.objects.filter(username="sync_new@test.com").exists()
 
         django_user.refresh_from_db()
         assert django_user.is_staff is False
         assert django_user.is_superuser is False
 
-        # Verify summary
         output = out.getvalue()
         assert "created" in output.lower()
         assert "updated" in output.lower()
         assert "skipped" in output.lower()
-        # Verify our specific users are mentioned
         assert "sync_new@test.com" in output
         assert "sync_update@test.com" in output
         assert "sync_skip@test.com" in output

--- a/services/experiments/src/models/sentiment_analyzer.py
+++ b/services/experiments/src/models/sentiment_analyzer.py
@@ -27,13 +27,9 @@ class JournalSentimentAnalyzer:
 
     def _preprocess_text(self, text: str) -> str:
         """Clean and preprocess text for sentiment analysis."""
-        # Convert to lowercase
         text = text.lower()
-
-        # Remove extra whitespace
         text = re.sub(r"\s+", " ", text)
-
-        # Keep punctuation as it can be important for sentiment
+        # Punctuation is intentionally preserved — it carries sentiment signal.
         text = text.strip()
 
         return text
@@ -49,7 +45,6 @@ class JournalSentimentAnalyzer:
         texts = []
         labels = []
 
-        # Reverse mapping for labels
         label_to_num = {v: k for k, v in self.sentiment_labels.items()}
 
         for item in training_data:
@@ -57,9 +52,8 @@ class JournalSentimentAnalyzer:
             texts.append(processed_text)
             labels.append(label_to_num[item["sentiment"]])
 
-        # Create pipeline with TF-IDF vectorizer and classifier
-        # Note: For text-only input, we use Pipeline directly.
-        # ColumnTransformer would be used if we had mixed feature types.
+        # Plain Pipeline is sufficient for text-only input; see
+        # SentimentAnalyzerWithFeatures below for the mixed-feature variant.
         self.sentiment_pipeline = Pipeline(
             [
                 (
@@ -76,7 +70,6 @@ class JournalSentimentAnalyzer:
             ]
         )
 
-        # Train the model
         self.sentiment_pipeline.fit(texts, labels)
 
         print(f"Sentiment model v{self.model_version} trained on {len(texts)} samples")
@@ -93,14 +86,12 @@ class JournalSentimentAnalyzer:
 
         processed_text = self._preprocess_text(text)
 
-        # Get prediction and probabilities
         prediction = self.sentiment_pipeline.predict([processed_text])[0]
         probabilities = self.sentiment_pipeline.predict_proba([processed_text])[0]
 
         sentiment = self.sentiment_labels[prediction]
         confidence = float(max(probabilities))
 
-        # Determine confidence level
         if confidence >= self.confidence_thresholds["high"]:
             confidence_level = "high"
         elif confidence >= self.confidence_thresholds["medium"]:
@@ -235,7 +226,6 @@ class SentimentAnalyzerWithFeatures:
         if self.pipeline is None:
             self.build_pipeline(text_column=text_column)
 
-        # Encode labels
         label_to_num = {v: k for k, v in self.sentiment_labels.items()}
         y = df[target_column].map(label_to_num)
 

--- a/services/experiments/src/training/train_article_recommender.py
+++ b/services/experiments/src/training/train_article_recommender.py
@@ -21,7 +21,6 @@ from sklearn.multioutput import MultiOutputClassifier
 from sklearn.pipeline import Pipeline
 from sklearn.preprocessing import StandardScaler
 
-# Set random seed for reproducibility
 np.random.seed(42)
 
 
@@ -48,14 +47,8 @@ class ArticleRecommenderWrapper(mlflow.pyfunc.PythonModel):
         self.articles_df = pd.read_parquet(context.artifacts["articles_db"])
         self.article_topic_map = pd.read_parquet(context.artifacts["article_topic_map"])
 
-        # all of the preprocessing and model steps were baked into this pipeline object,
-        # stored when we called `pipeline.fit`, and then saved to MLflow.
-
-        # now the API can load the model back in and use it for predictions on new data
-        # using the those same steps
         self.pipeline = mlflow.sklearn.load_model(context.artifacts["sklearn_pipeline"])
 
-        # Cache feature columns expected by pipeline
         self._user_feature_cols = ["favorite_topics"]
         self._session_feature_cols = ["time_on_site"]
         self._article_feature_cols = ["articles_read"]
@@ -85,23 +78,20 @@ class ArticleRecommenderWrapper(mlflow.pyfunc.PythonModel):
             how="left",
         )
 
-        # Check for unknown users - use default topics for new users
+        # Fall back to a default favorite topic for unknown users so the
+        # pipeline still has a value to encode.
         unknown_mask = enriched["favorite_topics"].isna()
         if unknown_mask.any():
             enriched.loc[unknown_mask, "favorite_topics"] = enriched.loc[
                 unknown_mask, "favorite_topics"
             ].apply(lambda x: ["tech"])
 
-        # Get probabilities for each article
-        # The pipeline expects the raw features and handles all preprocessing
         probabilities = self.pipeline.predict_proba(enriched)
 
-        # Format recommendations for each input row
         results = []
         for idx, row in enumerate(model_input.itertuples()):
-            # Get probabilities for this row across all articles
             if isinstance(probabilities, list):
-                # MultiOutputClassifier returns list of arrays
+                # MultiOutputClassifier returns a list of per-article arrays.
                 row_probs = np.array(
                     [p[idx, 1] if p.shape[1] > 1 else p[idx, 0] for p in probabilities]
                 )
@@ -132,14 +122,12 @@ class ArticleRecommenderWrapper(mlflow.pyfunc.PythonModel):
         Returns:
             Dict with user_id and list of top_k recommendations sorted by score
         """
-        # Get top k article indices by probability (descending)
         top_indices = np.argsort(probabilities)[::-1]
 
         recommendations = []
         for article_idx in top_indices:
             article_id = self.articles_df.iloc[article_idx]["article_id"]
 
-            # Skip articles already read
             if article_id in articles_read:
                 continue
 
@@ -176,10 +164,8 @@ def generate_dummy_data(
 
     print("Generating dummy data...")
 
-    # Define our article universe
-    all_articles = [f"article_{i}" for i in range(1, 51)]  # 50 articles
+    all_articles = [f"article_{i}" for i in range(1, 51)]
 
-    # Define topics
     topics = [
         "tech",
         "sports",
@@ -193,22 +179,19 @@ def generate_dummy_data(
         "fashion",
     ]
 
-    # Assign topics to articles (each article has 1-3 topics)
+    # Assign 1-3 topics to each article.
     article_topic_map = {}
     for article in all_articles:
         n_topics = np.random.randint(1, 4)
         article_topics = np.random.choice(topics, n_topics, replace=False).tolist()
         article_topic_map[article] = article_topics
 
-    # Create articles dataframe
     articles_df = pd.DataFrame({"article_id": all_articles})
 
-    # Create article topic map dataframe
     article_topic_df = pd.DataFrame(
         [{"article_id": k, "topics": v} for k, v in article_topic_map.items()]
     )
 
-    # Generate user favorite topics
     user_favorite_topics = {}
     for i in range(200):
         user_id = f"user_{i}"
@@ -217,25 +200,21 @@ def generate_dummy_data(
             topics, n_fav_topics, replace=False
         ).tolist()
 
-    # Create users dataframe
     users_df = pd.DataFrame(
         [{"user_id": k, "favorite_topics": v} for k, v in user_favorite_topics.items()]
     )
 
-    # Generate training data
     data = []
     for i in range(n_samples):
-        user_id = f"user_{i % 200}"  # 200 unique users
+        user_id = f"user_{i % 200}"
         favorite_topics = user_favorite_topics[user_id]
 
-        # Generate articles read (2-8 articles)
         n_articles_read = np.random.randint(2, 9)
         articles_read = np.random.choice(all_articles, n_articles_read, replace=False).tolist()
 
-        # Time on site (in seconds) - correlated with number of articles
+        # Time on site in seconds, correlated with number of articles read.
         time_on_site = n_articles_read * np.random.randint(60, 300)
 
-        # Generate recommendations based on user preferences
         recommended = _generate_logical_recommendations(
             articles_read, favorite_topics, all_articles, article_topic_map
         )
@@ -264,31 +243,28 @@ def _generate_logical_recommendations(
 ) -> list[str]:
     """Generate logical recommendations based on rules"""
 
-    # Get topics from articles read
     read_topics = set()
     for article in articles_read:
         read_topics.update(article_topic_map[article])
 
-    # Combine with favorite topics
     relevant_topics = read_topics.union(set(favorite_topics))
 
-    # Find articles matching these topics that haven't been read
     candidates = []
     for article in all_articles:
         if article not in articles_read:
             article_topics = set(article_topic_map[article])
-            # Score based on topic overlap
             overlap = len(article_topics.intersection(relevant_topics))
             if overlap > 0:
                 candidates.append((article, overlap))
 
-    # Sort by overlap and add some randomness
+    # Jitter the sort so identical-overlap candidates don't always tie-break
+    # the same way — keeps synthetic training data from collapsing to a
+    # deterministic ordering.
     candidates.sort(key=lambda x: x[1] + np.random.random() * 0.5, reverse=True)
 
-    # Return top N
     recommended = [article for article, _ in candidates[:n_recommendations]]
 
-    # Fill with random articles if needed
+    # Backfill with random unread articles if topic overlap didn't yield enough.
     if len(recommended) < n_recommendations:
         remaining = [a for a in all_articles if a not in articles_read and a not in recommended]
         recommended.extend(
@@ -312,10 +288,9 @@ def create_training_features(
         X: DataFrame with features
         y: DataFrame with binary columns for each article (multi-label target)
     """
-    # Create features DataFrame
     X = df[["user_id", "articles_read", "time_on_site", "favorite_topics"]].copy()
 
-    # Create multi-label target (binary indicator for each article)
+    # Multi-label target: one binary indicator column per article.
     y_data = []
     for _, row in df.iterrows():
         article_indicators = {
@@ -334,19 +309,16 @@ def build_pipeline(all_articles: list[str]) -> Pipeline:
     Build sklearn pipeline with ColumnTransformer for preprocessing
     and MultiOutputClassifier for multi-label prediction.
     """
-    # Define preprocessing for different column types
-    # Note: articles_read and favorite_topics are lists, we need custom handling
-
+    # articles_read and favorite_topics are list columns handled by
+    # prepare_features_for_pipeline before reaching this transformer, so only
+    # time_on_site is scaled here.
     preprocessor = ColumnTransformer(
         transformers=[
             ("time_scaler", StandardScaler(), ["time_on_site"]),
-            # For list columns, we'll handle them differently
-            # Using passthrough for now and custom preprocessing
         ],
         remainder="drop",
     )
 
-    # Create the full pipeline
     pipeline = Pipeline(
         [
             ("preprocessor", preprocessor),
@@ -371,18 +343,16 @@ def prepare_features_for_pipeline(
     """
     result = df.copy()
 
-    # One-hot encode articles_read
     for article in all_articles:
         result[f"read_{article}"] = result["articles_read"].apply(
-            lambda x: 1 if article in x else 0
+            lambda x, article=article: 1 if article in x else 0
         )
 
-    # One-hot encode favorite_topics
     for topic in topics:
-        result[f"topic_{topic}"] = result["favorite_topics"].apply(lambda x: 1 if topic in x else 0)
+        result[f"topic_{topic}"] = result["favorite_topics"].apply(
+            lambda x, topic=topic: 1 if topic in x else 0
+        )
 
-    # Keep time_on_site as is
-    # Drop original list columns
     result = result.drop(columns=["articles_read", "favorite_topics", "user_id"])
 
     return result
@@ -398,10 +368,8 @@ def train_model(
 
     print("\nTraining model...")
 
-    # Define feature columns
     feature_cols = [col for col in X_train.columns if col != "user_id"]
 
-    # Build preprocessing pipeline
     preprocessor = ColumnTransformer(
         transformers=[
             ("scaler", StandardScaler(), ["time_on_site"]),
@@ -414,7 +382,6 @@ def train_model(
         remainder="drop",
     )
 
-    # Full pipeline
     pipeline = Pipeline(
         [
             ("preprocessor", preprocessor),
@@ -427,10 +394,8 @@ def train_model(
         ]
     )
 
-    # Fit the pipeline
     pipeline.fit(X_train, y_train)
 
-    # Evaluate
     y_pred = pipeline.predict(X_val)
 
     precision = precision_score(y_val, y_pred, average="samples", zero_division=0)
@@ -448,11 +413,9 @@ def train_model(
 def main():
     """Main training and demonstration function"""
 
-    # Set MLflow tracking
     mlflow.set_tracking_uri("http://localhost:5000")
     mlflow.set_experiment("article_recommendations")
 
-    # Define topics
     topics = [
         "tech",
         "sports",
@@ -466,43 +429,32 @@ def main():
         "fashion",
     ]
 
-    # Generate dummy data
     df, users_df, articles_df, article_topic_df = generate_dummy_data(n_samples=2000)
     all_articles = articles_df["article_id"].tolist()
 
-    # Prepare features
     X, y = create_training_features(df, all_articles)
 
-    # Convert list columns to one-hot encoded features
     X_prepared = prepare_features_for_pipeline(X, all_articles, topics)
 
-    # Split data
     X_train, X_val, y_train, y_val = train_test_split(X_prepared, y, test_size=0.2, random_state=42)
 
-    # Start MLflow run
     with mlflow.start_run(run_name="sklearn_recommender"):
-        # Log parameters
         mlflow.log_param("model_type", "random_forest_multioutput")
         mlflow.log_param("n_estimators", 100)
         mlflow.log_param("max_depth", 10)
         mlflow.log_param("n_samples", len(df))
         mlflow.log_param("n_articles", len(all_articles))
 
-        # Train model
         pipeline, metrics = train_model(X_train, y_train, X_val, y_val)
 
-        # Log metrics
         mlflow.log_metric("precision", metrics["precision"])
         mlflow.log_metric("recall", metrics["recall"])
         mlflow.log_metric("f1_score", metrics["f1"])
 
-        # Save artifacts to temporary directory
         with tempfile.TemporaryDirectory() as tmp_dir:
-            # Save the sklearn pipeline
             sklearn_path = os.path.join(tmp_dir, "sklearn_pipeline")
             mlflow.sklearn.save_model(pipeline, sklearn_path)
 
-            # Save user and article data as parquet
             users_path = os.path.join(tmp_dir, "users.parquet")
             articles_path = os.path.join(tmp_dir, "articles.parquet")
             article_topic_path = os.path.join(tmp_dir, "article_topic_map.parquet")
@@ -511,7 +463,6 @@ def main():
             articles_df.to_parquet(articles_path, index=False)
             article_topic_df.to_parquet(article_topic_path, index=False)
 
-            # Define artifact paths for the wrapper
             artifact_paths = {
                 "users_db": users_path,
                 "articles_db": articles_path,
@@ -519,7 +470,6 @@ def main():
                 "sklearn_pipeline": sklearn_path,
             }
 
-            # Log the complete model with wrapper
             mlflow.pyfunc.log_model(
                 artifact_path="recommender_model",
                 python_model=ArticleRecommenderWrapper(),
@@ -537,17 +487,14 @@ def main():
 
         print("Training complete! Model logged to MLflow.")
 
-    # Demo prediction
     print("\n" + "=" * 60)
     print("DEMO PREDICTION")
     print("=" * 60)
 
-    # Load the model back
     model_uri = "models:/article_recommender/latest"
     try:
         loaded_model = mlflow.pyfunc.load_model(model_uri)
 
-        # Create sample input
         sample_input = pd.DataFrame(
             [
                 {

--- a/services/experiments/src/training/train_example.py
+++ b/services/experiments/src/training/train_example.py
@@ -40,11 +40,9 @@ class ExampleModelWrapper(mlflow.pyfunc.PythonModel):
         """
         self.pipeline = mlflow.sklearn.load_model(context.artifacts["sklearn_pipeline"])
 
-        # Load label encoder for target variable
         with open(context.artifacts["label_encoder"], "rb") as f:
             self.label_encoder = pickle.load(f)
 
-        # Load configuration
         with open(context.artifacts["model_config"], "rb") as f:
             self.config = pickle.load(f)
 
@@ -62,24 +60,19 @@ class ExampleModelWrapper(mlflow.pyfunc.PythonModel):
             List of prediction dicts, one per input row:
             [{"prediction": "class_a", "confidence": 0.85, "probabilities": {...}}, ...]
         """
-        # Ensure required columns are present
         missing_cols = set(self._feature_cols) - set(model_input.columns)
         if missing_cols:
             raise ValueError(f"Missing required columns: {missing_cols}")
 
-        # Select only feature columns in expected order
         X = model_input[self._feature_cols]
 
-        # Get predictions and probabilities
         predictions = self.pipeline.predict(X)
         probabilities = self.pipeline.predict_proba(X)
 
         results = []
         for i, pred in enumerate(predictions):
-            # Decode the label
             pred_label = self.label_encoder.inverse_transform([pred])[0]
 
-            # Get probability for each class
             proba_dict = {
                 self.label_encoder.inverse_transform([j])[0]: round(float(prob), 4)
                 for j, prob in enumerate(probabilities[i])
@@ -121,7 +114,7 @@ def generate_dummy_data(n_samples: int = 1000) -> pd.DataFrame:
         "target": np.random.choice(["positive", "negative", "neutral"], n_samples),
     }
 
-    # Make target somewhat correlated with features
+    # Inject a non-random signal so the classifier has something to learn.
     df = pd.DataFrame(data)
     df.loc[(df["numeric_feature_1"] > 0.5) & (df["category"] == "A"), "target"] = "positive"
     df.loc[(df["numeric_feature_1"] < -0.5) & (df["category"] == "C"), "target"] = "negative"
@@ -140,7 +133,6 @@ def build_pipeline(numeric_features: list[str], categorical_features: list[str])
     Returns:
         Configured sklearn Pipeline
     """
-    # Define preprocessing for different column types
     preprocessor = ColumnTransformer(
         transformers=[
             ("numeric", StandardScaler(), numeric_features),
@@ -149,7 +141,6 @@ def build_pipeline(numeric_features: list[str], categorical_features: list[str])
         remainder="drop",
     )
 
-    # Create the full pipeline
     pipeline = Pipeline(
         [
             ("preprocessor", preprocessor),
@@ -166,66 +157,52 @@ def build_pipeline(numeric_features: list[str], categorical_features: list[str])
 def train_and_register():
     """Train and register the example model."""
 
-    # Setup MLflow
     mlflow.set_tracking_uri("http://localhost:5000")
     mlflow.set_experiment("example_experiment")
 
-    # Generate or load data
     df = generate_dummy_data(n_samples=1000)
 
-    # Define feature columns
     numeric_features = ["numeric_feature_1", "numeric_feature_2"]
     categorical_features = ["category"]
     feature_cols = numeric_features + categorical_features
 
     with mlflow.start_run(run_name="example_model"):
-        # Prepare features and target
         X = df[feature_cols]
         y_raw = df["target"]
 
-        # Encode target labels
         label_encoder = LabelEncoder()
         y = label_encoder.fit_transform(y_raw)
 
-        # Split data
         X_train, X_val, y_train, y_val = train_test_split(
             X, y, test_size=0.2, random_state=42, stratify=y
         )
 
-        # Build and train pipeline
         pipeline = build_pipeline(numeric_features, categorical_features)
         pipeline.fit(X_train, y_train)
 
-        # Log parameters
         mlflow.log_param("model_type", "random_forest")
         mlflow.log_param("n_estimators", 100)
         mlflow.log_param("max_depth", 10)
         mlflow.log_param("training_samples", len(X_train))
         mlflow.log_param("validation_samples", len(X_val))
 
-        # Evaluate
         train_score = pipeline.score(X_train, y_train)
         val_score = pipeline.score(X_val, y_val)
 
-        # Log metrics
         mlflow.log_metric("train_accuracy", train_score)
         mlflow.log_metric("val_accuracy", val_score)
 
         print(f"Training Accuracy: {train_score:.4f}")
         print(f"Validation Accuracy: {val_score:.4f}")
 
-        # Save artifacts to temporary directory
         with tempfile.TemporaryDirectory() as tmp_dir:
-            # Save the sklearn pipeline
             sklearn_path = os.path.join(tmp_dir, "sklearn_pipeline")
             mlflow.sklearn.save_model(pipeline, sklearn_path)
 
-            # Save label encoder
             label_encoder_path = os.path.join(tmp_dir, "label_encoder.pkl")
             with open(label_encoder_path, "wb") as f:
                 pickle.dump(label_encoder, f)
 
-            # Save model configuration
             config = {
                 "feature_cols": feature_cols,
                 "numeric_features": numeric_features,
@@ -236,14 +213,12 @@ def train_and_register():
             with open(config_path, "wb") as f:
                 pickle.dump(config, f)
 
-            # Define artifact paths for the wrapper
             artifact_paths = {
                 "sklearn_pipeline": sklearn_path,
                 "label_encoder": label_encoder_path,
                 "model_config": config_path,
             }
 
-            # Log the complete model with wrapper
             print("\nLogging model with pyfunc wrapper...")
             mlflow.pyfunc.log_model(
                 artifact_path="example_model",
@@ -260,12 +235,10 @@ def train_and_register():
             )
             print("Model logged successfully!")
 
-        # Demonstrate loading and using the model
         print("\n" + "=" * 60)
         print("DEMO: Loading and using the model")
         print("=" * 60)
 
-        # Create sample input
         sample_input = pd.DataFrame(
             [
                 {"numeric_feature_1": 0.8, "numeric_feature_2": 55.0, "category": "A"},
@@ -274,7 +247,6 @@ def train_and_register():
             ]
         )
 
-        # Create wrapper instance for demo
         wrapper = ExampleModelWrapper()
         wrapper.pipeline = pipeline
         wrapper.label_encoder = label_encoder

--- a/services/experiments/src/training/train_sentiment_analysis.py
+++ b/services/experiments/src/training/train_sentiment_analysis.py
@@ -40,13 +40,11 @@ class SentimentAnalyzerWrapper(mlflow.pyfunc.PythonModel):
         """
         self.pipeline = mlflow.sklearn.load_model(context.artifacts["sklearn_pipeline"])
 
-        # Load label encoder
         import pickle
 
         with open(context.artifacts["label_encoder"], "rb") as f:
             self.label_encoder = pickle.load(f)
 
-        # Load sentiment labels mapping
         self.sentiment_labels = pd.read_parquet(context.artifacts["sentiment_labels"])
         self._label_map = dict(
             zip(
@@ -83,17 +81,14 @@ class SentimentAnalyzerWrapper(mlflow.pyfunc.PythonModel):
 
     def _predict_single(self, text: str) -> dict[str, Any]:
         """Predict sentiment for a single text."""
-        # Preprocess text
         processed_text = self._preprocess_text(text)
 
-        # Get prediction and probabilities
         prediction = self.pipeline.predict([processed_text])[0]
         probabilities = self.pipeline.predict_proba([processed_text])[0]
 
         sentiment = self._label_map[prediction]
         confidence = float(max(probabilities))
 
-        # Determine confidence level
         if confidence >= self.confidence_thresholds["high"]:
             confidence_level = "high"
         elif confidence >= self.confidence_thresholds["medium"]:
@@ -319,23 +314,18 @@ def build_sentiment_pipeline() -> Pipeline:
 def train_and_register():
     """Train and register the sentiment analysis model."""
 
-    # Set MLflow tracking
     mlflow.set_tracking_uri("http://localhost:5000")
     mlflow.set_experiment("journal_sentiment_analysis")
 
-    # Get training data
     training_data = get_training_data()
 
     with mlflow.start_run(run_name="sentiment_analyzer"):
-        # Prepare data
         texts = [item["text"] for item in training_data]
         sentiments = [item["sentiment"] for item in training_data]
 
-        # Encode labels
         label_encoder = LabelEncoder()
         labels = label_encoder.fit_transform(sentiments)
 
-        # Create sentiment labels dataframe
         sentiment_labels_df = pd.DataFrame(
             {
                 "label_id": range(len(label_encoder.classes_)),
@@ -343,28 +333,23 @@ def train_and_register():
             }
         )
 
-        # Split data for validation
         X_train, X_test, y_train, y_test = train_test_split(
             texts, labels, test_size=0.2, random_state=42, stratify=labels
         )
 
-        # Build and train pipeline
         pipeline = build_sentiment_pipeline()
         pipeline.fit(X_train, y_train)
 
-        # Log parameters
         mlflow.log_param("model_type", "multinomial_nb")
         mlflow.log_param("training_samples", len(X_train))
         mlflow.log_param("test_samples", len(X_test))
         mlflow.log_param("sentiment_classes", len(label_encoder.classes_))
 
-        # Evaluate
         y_pred = pipeline.predict(X_test)
         accuracy = accuracy_score(y_test, y_pred)
         y_proba = pipeline.predict_proba(X_test)
         avg_confidence = float(np.mean(np.max(y_proba, axis=1)))
 
-        # Log metrics
         mlflow.log_metric("accuracy", accuracy)
         mlflow.log_metric("avg_confidence", avg_confidence)
 
@@ -373,7 +358,6 @@ def train_and_register():
         print("\nClassification Report:")
         print(classification_report(y_test, y_pred, target_names=label_encoder.classes_))
 
-        # Test with sample cases
         test_cases = [
             "I feel amazing today! Everything is going perfectly.",
             "I'm worried about the future and feel overwhelmed.",
@@ -391,31 +375,25 @@ def train_and_register():
             mlflow.log_metric(f"test_case_{i}_confidence", confidence)
             print(f"{i}. '{test_text[:50]}...' -> {sentiment} ({confidence:.3f})")
 
-        # Save artifacts to temporary directory
         with tempfile.TemporaryDirectory() as tmp_dir:
-            # Save the sklearn pipeline
             sklearn_path = os.path.join(tmp_dir, "sklearn_pipeline")
             mlflow.sklearn.save_model(pipeline, sklearn_path)
 
-            # Save label encoder
             import pickle
 
             label_encoder_path = os.path.join(tmp_dir, "label_encoder.pkl")
             with open(label_encoder_path, "wb") as f:
                 pickle.dump(label_encoder, f)
 
-            # Save sentiment labels
             sentiment_labels_path = os.path.join(tmp_dir, "sentiment_labels.parquet")
             sentiment_labels_df.to_parquet(sentiment_labels_path, index=False)
 
-            # Define artifact paths for the wrapper
             artifact_paths = {
                 "sklearn_pipeline": sklearn_path,
                 "label_encoder": label_encoder_path,
                 "sentiment_labels": sentiment_labels_path,
             }
 
-            # Log the complete model with wrapper
             print("Logging model with pyfunc wrapper...")
             mlflow.pyfunc.log_model(
                 artifact_path="sentiment_model",
@@ -433,7 +411,6 @@ def train_and_register():
             )
             print("Model logged successfully!")
 
-        # Demonstrate trend analysis capability
         print("\nSample trend analysis:")
         sample_entries = [
             {"text": "Great start to the week!", "date": "2024-01-01"},
@@ -442,9 +419,8 @@ def train_and_register():
             {"text": "Accomplished so much today!", "date": "2024-01-04"},
         ]
 
-        # Create wrapper instance for demo
-        wrapper = SentimentAnalyzerWrapper()
         # Manually set up for demo (in production, load_context handles this)
+        wrapper = SentimentAnalyzerWrapper()
         wrapper.pipeline = pipeline
         wrapper.label_encoder = label_encoder
         wrapper._label_map = dict(enumerate(label_encoder.classes_))

--- a/services/experiments/src/training/train_topics_semantic.py
+++ b/services/experiments/src/training/train_topics_semantic.py
@@ -275,17 +275,14 @@ def train_and_register() -> None:
         mlflow.log_param("taxonomy_subtopics", len(JOURNAL_TOPIC_TAXONOMY))
 
         with tempfile.TemporaryDirectory() as tmpdir:
-            # 1. Save sentence-transformer model.
             st_path = os.path.join(tmpdir, "sentence_transformer")
             logger.info("Downloading and saving sentence-transformer model: %s", model_name)
             SentenceTransformer(model_name).save(st_path)
 
-            # 2. Save hierarchy (domain → subtopic list mapping).
             hierarchy_path = os.path.join(tmpdir, "hierarchy.json")
             with open(hierarchy_path, "w") as f:
                 json.dump(JOURNAL_TOPIC_HIERARCHY, f, indent=2)
 
-            # 3. Save model config.
             config_path = os.path.join(tmpdir, "model_config.json")
             with open(config_path, "w") as f:
                 json.dump(config, f, indent=2)
@@ -296,7 +293,6 @@ def train_and_register() -> None:
                 "model_config": config_path,
             }
 
-            # 4. Validate the wrapper end-to-end before registering.
             logger.info("Running validation pass on sample entries...")
             wrapper = SemanticTopicExtractorWrapper()
             wrapper.load_context(  # type: ignore[arg-type]
@@ -322,7 +318,6 @@ def train_and_register() -> None:
                     len(topics),
                 )
 
-            # 5. Log and register the pyfunc model.
             # No code_paths needed — the wrapper is self-contained and only
             # uses installed packages (keybert, sentence-transformers, numpy).
             logger.info("Logging model to MLflow...")

--- a/services/experiments/tests/models/test_semantic_topic_extractor.py
+++ b/services/experiments/tests/models/test_semantic_topic_extractor.py
@@ -16,10 +16,6 @@ from src.models.semantic_topic_extractor import (
     SemanticTopicExtractor,
 )
 
-# ---------------------------------------------------------------------------
-# Helpers / fixtures
-# ---------------------------------------------------------------------------
-
 
 def _make_mock_extractor(taxonomy: list[str] | None = None) -> SemanticTopicExtractor:
     """Return a SemanticTopicExtractor with mocked sentence-transformer and KeyBERT.
@@ -55,11 +51,6 @@ def _make_mock_extractor(taxonomy: list[str] | None = None) -> SemanticTopicExtr
     return extractor
 
 
-# ---------------------------------------------------------------------------
-# Taxonomy tests
-# ---------------------------------------------------------------------------
-
-
 class TestTaxonomy:
     def test_default_taxonomy_not_empty(self):
         assert len(JOURNAL_TOPIC_TAXONOMY) > 0
@@ -69,11 +60,6 @@ class TestTaxonomy:
 
     def test_no_duplicate_taxonomy_entries(self):
         assert len(JOURNAL_TOPIC_TAXONOMY) == len(set(JOURNAL_TOPIC_TAXONOMY))
-
-
-# ---------------------------------------------------------------------------
-# Initialisation tests
-# ---------------------------------------------------------------------------
 
 
 class TestSemanticTopicExtractorInit:
@@ -92,11 +78,6 @@ class TestSemanticTopicExtractorInit:
     def test_default_min_confidence(self):
         extractor = _make_mock_extractor()
         assert extractor.min_confidence == 0.25
-
-
-# ---------------------------------------------------------------------------
-# extract_topics output format tests
-# ---------------------------------------------------------------------------
 
 
 class TestExtractTopicsFormat:
@@ -123,14 +104,13 @@ class TestExtractTopicsFormat:
         extractor = self._extractor_with_keyphrases([("work stress", 0.80)])
         result = extractor.extract_topics("Some text about work")
         for topic in result:
-            # confidence should have at most 4 decimal places
             assert round(topic["confidence"], 4) == topic["confidence"]
 
     def test_sorted_by_descending_confidence(self):
         extractor = _make_mock_extractor(taxonomy=["topic a", "topic b", "topic c"])
         extractor.taxonomy_embeddings = np.eye(3, dtype="float32")
 
-        # Simulate three distinct keyphrases mapping to different taxonomy entries
+        # Map each keyphrase to a distinct taxonomy entry so confidences differ.
         def mock_encode(text, **kwargs):
             phrase_map = {
                 "first phrase": np.array([[1.0, 0.0, 0.0]], dtype="float32"),
@@ -164,18 +144,13 @@ class TestExtractTopicsFormat:
 
     def test_low_confidence_keyphrases_filtered(self):
         extractor = _make_mock_extractor()
-        # All below min_confidence of 0.25
+        # All scores below the default min_confidence of 0.25.
         extractor.kw_model.extract_keywords.return_value = [
             ("low score phrase", 0.10),
             ("another low one", 0.20),
         ]
         result = extractor.extract_topics("Some text")
         assert result == []
-
-
-# ---------------------------------------------------------------------------
-# Adaptive keyphrase count tests
-# ---------------------------------------------------------------------------
 
 
 class TestAdaptiveKeyphraseCount:
@@ -211,16 +186,10 @@ class TestAdaptiveKeyphraseCount:
         assert captured[0] == 6
 
 
-# ---------------------------------------------------------------------------
-# Deduplication tests
-# ---------------------------------------------------------------------------
-
-
 class TestDeduplication:
     def test_duplicate_taxonomy_mappings_deduplicated(self):
         """Two keyphrases mapping to the same taxonomy entry should yield one topic."""
         extractor = _make_mock_extractor(taxonomy=["work and career"])
-        # Both keyphrases map to the only taxonomy entry (index 0).
         extractor.taxonomy_embeddings = np.ones((1, 4), dtype="float32")
         extractor.sentence_model.encode = lambda text, **kwargs: np.ones((1, 4), dtype="float32")
         extractor.kw_model.extract_keywords.return_value = [
@@ -229,7 +198,6 @@ class TestDeduplication:
         ]
 
         result = extractor.extract_topics("x " * 30)
-        # Should be deduplicated to a single topic
         assert len(result) == 1
         assert result[0]["topic_name"] == "work and career"
 
@@ -238,20 +206,14 @@ class TestDeduplication:
         extractor.taxonomy_embeddings = np.ones((1, 4), dtype="float32")
         extractor.sentence_model.encode = lambda text, **kwargs: np.ones((1, 4), dtype="float32")
         extractor.kw_model.extract_keywords.return_value = [
-            ("work deadline", 0.90),  # higher keyphrase score
-            ("office project", 0.40),  # lower
+            ("work deadline", 0.90),
+            ("office project", 0.40),
         ]
 
         result = extractor.extract_topics("x " * 30)
-        # Combined score for "work deadline": (0.90 + 1.0) / 2 = 0.95
-        # Combined score for "office project": (0.40 + 1.0) / 2 = 0.70
-        # Should keep the higher one
+        # Combined scores: "work deadline" → (0.90 + 1.0) / 2 = 0.95,
+        # "office project" → (0.40 + 1.0) / 2 = 0.70. The higher wins.
         assert result[0]["confidence"] > 0.70
-
-
-# ---------------------------------------------------------------------------
-# Batch extraction tests
-# ---------------------------------------------------------------------------
 
 
 class TestBatchExtraction:
@@ -272,11 +234,6 @@ class TestBatchExtraction:
         texts = ["a", "b", "c", "d", "e"]
         result = extractor.extract_topics_batch(texts)
         assert len(result) == len(texts)
-
-
-# ---------------------------------------------------------------------------
-# Integration test (skipped by default — requires real model)
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.integration

--- a/services/experiments/tests/models/test_sentiment_analyzer.py
+++ b/services/experiments/tests/models/test_sentiment_analyzer.py
@@ -4,7 +4,6 @@ from src.models.sentiment_analyzer import JournalSentimentAnalyzer, SentimentAna
 
 class TestJournalSentimentAnalyzer:
     def test_model_initialization(self):
-        """Test model initializes with correct parameters"""
         model = JournalSentimentAnalyzer(model_version="1.0.0")
         assert model.model_version == "1.0.0"
         assert model.sentiment_pipeline is None
@@ -12,7 +11,6 @@ class TestJournalSentimentAnalyzer:
         assert model.confidence_thresholds == {"high": 0.7, "medium": 0.5, "low": 0.3}
 
     def test_training_creates_pipeline(self, sentiment_training_data):
-        """Test that training creates the necessary pipeline"""
         model = JournalSentimentAnalyzer()
         model.train(sentiment_training_data)
 
@@ -21,14 +19,12 @@ class TestJournalSentimentAnalyzer:
         assert "classifier" in model.sentiment_pipeline.named_steps
 
     def test_predict_requires_trained_model(self):
-        """Test that prediction fails on untrained model"""
         model = JournalSentimentAnalyzer()
 
         with pytest.raises(ValueError, match="Model must be trained before making predictions"):
             model.predict_sentiment("test text")
 
     def test_predict_sentiment_output_format(self, trained_sentiment_model):
-        """Test that predictions have correct format"""
         result = trained_sentiment_model.predict_sentiment("I feel great today!")
 
         assert "sentiment" in result
@@ -43,14 +39,12 @@ class TestJournalSentimentAnalyzer:
         assert isinstance(result["all_scores"], dict)
 
     def test_predict_sentiment_all_scores_sum_to_one(self, trained_sentiment_model):
-        """Test that all_scores probabilities sum to approximately 1"""
         result = trained_sentiment_model.predict_sentiment("Test journal entry")
 
         total = sum(result["all_scores"].values())
-        assert abs(total - 1.0) < 0.01  # Allow small floating point error
+        assert abs(total - 1.0) < 0.01
 
     def test_predict_batch(self, trained_sentiment_model):
-        """Test batch prediction works correctly"""
         texts = ["Great day!", "Terrible experience", "Nothing special"]
         results = trained_sentiment_model.predict_batch(texts)
 
@@ -60,8 +54,6 @@ class TestJournalSentimentAnalyzer:
             assert "confidence" in result
 
     def test_confidence_levels(self, trained_sentiment_model):
-        """Test that confidence levels are assigned correctly based on thresholds"""
-        # We can't guarantee specific confidence values, but we can check the logic
         result = trained_sentiment_model.predict_sentiment("I am so incredibly happy!")
 
         if result["confidence"] >= 0.7:
@@ -72,7 +64,6 @@ class TestJournalSentimentAnalyzer:
             assert result["confidence_level"] == "low"
 
     def test_analyze_sentiment_trends(self, trained_sentiment_model):
-        """Test sentiment trend analysis"""
         entries = [
             {"text": "Great start to the week!", "date": "2024-01-01"},
             {"text": "Feeling stressed about work", "date": "2024-01-02"},
@@ -92,7 +83,6 @@ class TestJournalSentimentAnalyzer:
         assert trends["dominant_sentiment"] in ["positive", "negative", "neutral"]
 
     def test_analyze_sentiment_trends_includes_dates(self, trained_sentiment_model):
-        """Test that trend analysis preserves dates"""
         entries = [
             {"text": "Happy day!", "date": "2024-01-01"},
             {"text": "Sad day!", "date": "2024-01-02"},
@@ -104,14 +94,12 @@ class TestJournalSentimentAnalyzer:
             assert "date" in result
 
     def test_get_model_info_untrained(self):
-        """Test model info for untrained model"""
         model = JournalSentimentAnalyzer()
         info = model.get_model_info()
 
         assert info["status"] == "not_trained"
 
     def test_get_model_info_trained(self, trained_sentiment_model):
-        """Test model info for trained model"""
         info = trained_sentiment_model.get_model_info()
 
         assert info["status"] == "trained"
@@ -122,28 +110,19 @@ class TestJournalSentimentAnalyzer:
         assert info["vocabulary_size"] > 0
 
     def test_text_preprocessing(self):
-        """Test that text preprocessing works correctly"""
         model = JournalSentimentAnalyzer()
 
-        # Test lowercase conversion
         assert model._preprocess_text("HELLO WORLD") == "hello world"
-
-        # Test whitespace normalization
         assert model._preprocess_text("hello   world") == "hello world"
-
-        # Test stripping
         assert model._preprocess_text("  hello  ") == "hello"
 
     def test_empty_text_handling(self, trained_sentiment_model):
-        """Test behavior with empty text"""
         result = trained_sentiment_model.predict_sentiment("")
 
-        # Should still return a valid result structure
         assert "sentiment" in result
         assert "confidence" in result
 
     def test_reproducible_results(self, sentiment_training_data):
-        """Test that same training data produces same predictions"""
         text = "I feel great today!"
 
         model1 = JournalSentimentAnalyzer()
@@ -162,14 +141,12 @@ class TestSentimentAnalyzerWithFeatures:
     """Tests for the extended SentimentAnalyzerWithFeatures class"""
 
     def test_model_initialization(self):
-        """Test model initializes with correct parameters"""
         model = SentimentAnalyzerWithFeatures(model_version="1.0.0")
         assert model.model_version == "1.0.0"
         assert model.pipeline is None
         assert model.sentiment_labels == {0: "negative", 1: "neutral", 2: "positive"}
 
     def test_build_pipeline_text_only(self):
-        """Test building pipeline with text column only"""
         model = SentimentAnalyzerWithFeatures()
         pipeline = model.build_pipeline(text_column="text")
 
@@ -178,7 +155,6 @@ class TestSentimentAnalyzerWithFeatures:
         assert "classifier" in pipeline.named_steps
 
     def test_build_pipeline_with_numeric_columns(self):
-        """Test building pipeline with text and numeric columns"""
         model = SentimentAnalyzerWithFeatures()
         pipeline = model.build_pipeline(
             text_column="text",
@@ -192,7 +168,6 @@ class TestSentimentAnalyzerWithFeatures:
         assert "numeric" in transformer_names
 
     def test_build_pipeline_with_categorical_columns(self):
-        """Test building pipeline with text and categorical columns"""
         model = SentimentAnalyzerWithFeatures()
         pipeline = model.build_pipeline(
             text_column="text",
@@ -206,7 +181,6 @@ class TestSentimentAnalyzerWithFeatures:
         assert "categorical" in transformer_names
 
     def test_build_pipeline_with_all_column_types(self):
-        """Test building pipeline with all column types"""
         model = SentimentAnalyzerWithFeatures()
         pipeline = model.build_pipeline(
             text_column="text",
@@ -226,7 +200,6 @@ class TestSentimentAnalyzerPerformance:
     """Performance tests for sentiment analyzer"""
 
     def test_inference_speed(self, trained_sentiment_model):
-        """Test that inference completes quickly"""
         import time
 
         text = "Today was a wonderful day with great achievements and happy moments"
@@ -235,11 +208,10 @@ class TestSentimentAnalyzerPerformance:
         result = trained_sentiment_model.predict_sentiment(text)
         duration = time.time() - start_time
 
-        assert duration < 1.0  # Should complete in under 1 second
+        assert duration < 1.0
         assert "sentiment" in result
 
     def test_batch_inference_speed(self, trained_sentiment_model):
-        """Test that batch inference is reasonably fast"""
         import time
 
         texts = ["Text number " + str(i) for i in range(100)]

--- a/services/frontend/__tests__/actions/journals.test.ts
+++ b/services/frontend/__tests__/actions/journals.test.ts
@@ -1,17 +1,8 @@
-/**
- * Tests for actions/journals.ts (createJournal server action)
- *
- * Mocks auth(), revalidatePath(), and global fetch to test the full
- * server action logic: auth checks, validation, backend calls, and
- * cache revalidation.
- */
-
-// Mock next/cache before importing the module under test
+// next/cache must be mocked before importing the module under test so revalidatePath is the jest mock.
 jest.mock("next/cache", () => ({
   revalidatePath: jest.fn(),
 }));
 
-// Mock auth
 jest.mock("@/auth", () => ({
   auth: jest.fn(),
 }));
@@ -27,9 +18,6 @@ const mockRevalidatePath = revalidatePath as jest.MockedFunction<
 const mockFetch = jest.fn();
 global.fetch = mockFetch;
 
-// ---------------------------------------------------------------------------
-// Setup
-// ---------------------------------------------------------------------------
 beforeEach(() => {
   jest.clearAllMocks();
   jest.spyOn(console, "error").mockImplementation(() => {});
@@ -39,9 +27,6 @@ afterEach(() => {
   jest.restoreAllMocks();
 });
 
-// ---------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------
 describe("createJournal", () => {
   test("returns Unauthorized when session has no user id", async () => {
     mockAuth.mockResolvedValueOnce(null as never);
@@ -96,7 +81,6 @@ describe("createJournal", () => {
       moodScore: 7,
     });
 
-    // Verify fetch was called with correct payload
     expect(mockFetch).toHaveBeenCalledWith(
       expect.stringContaining("/v1/journals"),
       expect.objectContaining({

--- a/services/frontend/__tests__/actions/user.test.ts
+++ b/services/frontend/__tests__/actions/user.test.ts
@@ -1,7 +1,3 @@
-/**
- * Tests for actions/user.ts (updateTimezone server action)
- */
-
 jest.mock("next/cache", () => ({}));
 jest.mock("@/auth", () => ({
   auth: jest.fn(),

--- a/services/frontend/__tests__/api/v1/csgodouble/roll.test.ts
+++ b/services/frontend/__tests__/api/v1/csgodouble/roll.test.ts
@@ -1,6 +1,4 @@
 /**
- * Tests for app/api/v1/csgodouble/roll/route.ts
- *
  * @jest-environment node
  */
 

--- a/services/frontend/__tests__/api/v1/csgodouble/state.test.ts
+++ b/services/frontend/__tests__/api/v1/csgodouble/state.test.ts
@@ -1,6 +1,4 @@
 /**
- * Tests for app/api/v1/csgodouble/state/route.ts
- *
  * @jest-environment node
  */
 

--- a/services/frontend/__tests__/api/v1/sync-user-records.test.ts
+++ b/services/frontend/__tests__/api/v1/sync-user-records.test.ts
@@ -1,8 +1,4 @@
 /**
- * Tests for app/api/v1/sync-user-records/route.ts
- *
- * Unit tests for the sync-user-records example API endpoint.
- *
  * @jest-environment node
  */
 

--- a/services/frontend/__tests__/app/page.test.tsx
+++ b/services/frontend/__tests__/app/page.test.tsx
@@ -1,7 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import { LoggedInDashboard } from "@/components/dashboard/LoggedInDashboard";
 
-// Mock next/link
 jest.mock("next/link", () => {
   return ({ children, href }: { children: React.ReactNode; href: string }) => (
     <a href={href}>{children}</a>

--- a/services/frontend/__tests__/app/signin.test.tsx
+++ b/services/frontend/__tests__/app/signin.test.tsx
@@ -1,13 +1,11 @@
 import { render, screen } from "@testing-library/react";
 import SignInPage from "@/app/signin/page";
 
-// Mock @/auth
 jest.mock("@/auth", () => ({
-  auth: jest.fn().mockResolvedValue(null), // unauthenticated
+  auth: jest.fn().mockResolvedValue(null),
   signIn: jest.fn(),
 }));
 
-// Mock next/navigation
 jest.mock("next/navigation", () => ({
   redirect: jest.fn(),
   useRouter: jest.fn(() => ({
@@ -30,10 +28,7 @@ jest.mock("lucide-react", () => ({
   Mail: () => <svg data-testid="mail-icon" />,
 }));
 
-/**
- * Helper to render the async server component.
- * Server components are async functions — we call them and await the JSX.
- */
+// SignInPage is an async server component, so we invoke it and render the resolved JSX.
 async function renderSignInPage(searchParams = {}) {
   const jsx = await SignInPage({
     searchParams: Promise.resolve(searchParams),

--- a/services/frontend/__tests__/auth/auth.test.ts
+++ b/services/frontend/__tests__/auth/auth.test.ts
@@ -10,7 +10,6 @@
  */
 
 jest.mock("next-auth", () => {
-  // Return a function that simply returns mock exports
   const mockFn = jest.fn((config) => ({
     handlers: {},
     auth: jest.fn(),
@@ -43,19 +42,16 @@ jest.mock("@/lib/config", () => ({
   BACKEND_API_KEY: "test-api-key",
 }));
 
-// Now we can import authConfig -- NextAuth() is mocked so it won't
-// try to initialize the full auth system
+// Imported after the NextAuth mock so it doesn't try to initialize the full auth system.
 import { authConfig, __clearBackendUserCacheForTests } from "@/auth";
 
 const mockFetch = jest.fn();
 global.fetch = mockFetch;
 
-// ---------------------------------------------------------------------------
-// Setup
-// ---------------------------------------------------------------------------
 beforeEach(() => {
   jest.clearAllMocks();
-  mockFetch.mockReset(); // clear implementation queue so no leftover mockResolvedValueOnce from previous tests
+  // clear the implementation queue so no leftover mockResolvedValueOnce from previous tests
+  mockFetch.mockReset();
   __clearBackendUserCacheForTests();
   jest.spyOn(console, "error").mockImplementation(() => {});
   jest.spyOn(console, "log").mockImplementation(() => {});
@@ -67,9 +63,6 @@ afterEach(() => {
 
 const callbacks = authConfig.callbacks!;
 
-// ---------------------------------------------------------------------------
-// signIn callback
-// ---------------------------------------------------------------------------
 describe("signIn callback", () => {
   const signIn = callbacks.signIn!;
 
@@ -107,14 +100,12 @@ describe("signIn callback", () => {
   });
 
   test("creates new user when not found in backend", async () => {
-    // fetchBackendUser returns 404
+    // fetchBackendUser -> createUserInBackend -> fetchBackendUser (post-create)
     mockFetch.mockResolvedValueOnce({ ok: false, status: 404 });
-    // createUserInBackend succeeds
     mockFetch.mockResolvedValueOnce({
       ok: true,
       json: async () => ({ userId: "new-user-456" }),
     });
-    // fetchBackendUser after creation succeeds
     mockFetch.mockResolvedValueOnce({
       ok: true,
       json: async () => ({
@@ -212,7 +203,6 @@ describe("signIn callback", () => {
     >;
     await signIn({ user, account: { provider: "github" } } as never);
 
-    // First fetch call is fetchBackendUser
     expect(mockFetch).toHaveBeenCalledWith(
       expect.any(String),
       expect.objectContaining({
@@ -224,14 +214,11 @@ describe("signIn callback", () => {
   });
 
   test("sends Authorization Bearer header on createUserInBackend", async () => {
-    // fetchBackendUser returns 404
     mockFetch.mockResolvedValueOnce({ ok: false, status: 404 });
-    // createUserInBackend succeeds
     mockFetch.mockResolvedValueOnce({
       ok: true,
       json: async () => ({ userId: "new-u" }),
     });
-    // fetchBackendUser after creation
     mockFetch.mockResolvedValueOnce({
       ok: true,
       json: async () => ({
@@ -247,7 +234,6 @@ describe("signIn callback", () => {
     >;
     await signIn({ user, account: { provider: "github" } } as never);
 
-    // Second fetch call is the POST to create user
     const createCall = mockFetch.mock.calls[1];
     expect(createCall[1].headers).toEqual(
       expect.objectContaining({
@@ -274,7 +260,6 @@ describe("signIn callback", () => {
     const user = { email: "new@example.com" } as Record<string, unknown>;
     await signIn({ user, account: { provider: "github" } } as never);
 
-    // Second fetch call is the POST to create the user
     const createCall = mockFetch.mock.calls[1];
     const body = JSON.parse(createCall[1].body);
     expect(body.oauth_provider).toBe("github");
@@ -282,9 +267,6 @@ describe("signIn callback", () => {
   });
 });
 
-// ---------------------------------------------------------------------------
-// jwt callback
-// ---------------------------------------------------------------------------
 describe("jwt callback", () => {
   const jwt = callbacks.jwt!;
 
@@ -299,7 +281,7 @@ describe("jwt callback", () => {
   });
 
   test("preserves existing token when no user (subsequent requests)", async () => {
-    // Token already has backendId; we do not fetch (rely on JWT after login).
+    // With backendId already on the token we rely on JWT after login and do not refetch.
     const result = await jwt({
       token: {
         backendId: "existing-id",
@@ -324,9 +306,6 @@ describe("jwt callback", () => {
   });
 });
 
-// ---------------------------------------------------------------------------
-// session callback
-// ---------------------------------------------------------------------------
 describe("session callback", () => {
   const session = callbacks.session!;
 
@@ -367,26 +346,22 @@ describe("session callback", () => {
   });
 });
 
-// ---------------------------------------------------------------------------
-// signIn callback - magic link (email) provider
-// ---------------------------------------------------------------------------
 describe("signIn callback - magic link (email provider)", () => {
   const signIn = callbacks.signIn!;
 
   test("allows phase-1 email send when user has no id yet", async () => {
-    // Phase-1: email is being sent, user.id is not populated
+    // Phase-1: email is being sent; user.id isn't populated, so we shouldn't hit the backend.
     const result = await signIn({
       user: { email: "magic@example.com" },
       account: { provider: "resend" },
     } as never);
 
     expect(result).toBe(true);
-    // No backend calls should happen during phase-1
     expect(mockFetch).not.toHaveBeenCalled();
   });
 
   test("syncs with backend on phase-2 for existing user", async () => {
-    // Phase-2: user clicked the magic link, user.id is set by the adapter
+    // Phase-2: user clicked the magic link, user.id is set by the adapter.
     mockFetch.mockResolvedValueOnce({
       ok: true,
       json: async () => ({
@@ -411,15 +386,12 @@ describe("signIn callback - magic link (email provider)", () => {
   });
 
   test("creates new user in backend on phase-2 with provider 'email'", async () => {
-    // Phase-2: user clicked the magic link but doesn't exist in backend yet
-    // fetchBackendUser returns 404
+    // Phase-2: user clicked the magic link but doesn't exist in backend yet.
     mockFetch.mockResolvedValueOnce({ ok: false, status: 404 });
-    // createUserInBackend succeeds
     mockFetch.mockResolvedValueOnce({
       ok: true,
       json: async () => ({ userId: "new-email-user-200" }),
     });
-    // fetchBackendUser after creation succeeds
     mockFetch.mockResolvedValueOnce({
       ok: true,
       json: async () => ({
@@ -441,7 +413,7 @@ describe("signIn callback - magic link (email provider)", () => {
     expect(result).toBe(true);
     expect(user.backendId).toBe("new-email-user-200");
 
-    // Verify the create call used "email" as the oauth_provider
+    // The create call must use "email" as the oauth_provider (not "resend").
     const createCall = mockFetch.mock.calls[1];
     const body = JSON.parse(createCall[1].body);
     expect(body.oauth_provider).toBe("email");
@@ -449,14 +421,11 @@ describe("signIn callback - magic link (email provider)", () => {
   });
 });
 
-// ---------------------------------------------------------------------------
-// jwt callback - magic link fallback paths
-// ---------------------------------------------------------------------------
 describe("jwt callback - magic link fallback paths", () => {
   const jwt = callbacks.jwt!;
 
   test("falls back to user.id when user.backendId is missing (adapter user)", async () => {
-    // The adapter returns AdapterUser with id = backend UUID, no backendId field
+    // The magic-link adapter returns an AdapterUser with id = backend UUID and no backendId field.
     const result = await jwt({
       token: {},
       user: { id: "adapter-uuid-999", email: "adapter@example.com" },
@@ -467,8 +436,8 @@ describe("jwt callback - magic link fallback paths", () => {
   });
 
   test("looks up backend user by email when backendId is still missing", async () => {
-    // Scenario: token has email but no backendId (user object had neither
-    // backendId nor a useful id). JWT callback does one lookup; no refresh fetch.
+    // Token has email but no backendId (user object had neither backendId nor a useful id),
+    // so the JWT callback does a single email lookup and no refresh fetch.
     mockFetch.mockResolvedValueOnce({
       ok: true,
       json: async () => ({
@@ -490,14 +459,12 @@ describe("jwt callback - magic link fallback paths", () => {
   });
 
   test("creates user in backend when email lookup returns null", async () => {
-    // fetchBackendUser returns null (404)
+    // fetchBackendUser (404) -> createUserInBackend -> fetchBackendUser -> always-refresh-role lookup.
     mockFetch.mockResolvedValueOnce({ ok: false, status: 404 });
-    // createUserInBackend succeeds
     mockFetch.mockResolvedValueOnce({
       ok: true,
       json: async () => ({ userId: "auto-created-id" }),
     });
-    // fetchBackendUser after creation
     mockFetch.mockResolvedValueOnce({
       ok: true,
       json: async () => ({
@@ -507,7 +474,6 @@ describe("jwt callback - magic link fallback paths", () => {
         timezone: "UTC",
       }),
     });
-    // Always-refresh-role lookup
     mockFetch.mockResolvedValueOnce({
       ok: true,
       json: async () => ({
@@ -528,9 +494,7 @@ describe("jwt callback - magic link fallback paths", () => {
   });
 
   test("handles failed email lookup and failed creation gracefully", async () => {
-    // fetchBackendUser returns 404
     mockFetch.mockResolvedValueOnce({ ok: false, status: 404 });
-    // createUserInBackend fails
     mockFetch.mockResolvedValueOnce({
       ok: false,
       status: 500,
@@ -542,12 +506,11 @@ describe("jwt callback - magic link fallback paths", () => {
       user: undefined,
     } as never);
 
-    // backendId should remain unset — no crash
+    // backendId must remain unset without crashing.
     expect(result!.backendId).toBeUndefined();
   });
 
   test("does not fetch when backendId is already on the token", async () => {
-    // We rely on JWT after login; no backend refresh when backendId is already set.
     const result = await jwt({
       token: { backendId: "already-set", email: "skip@example.com" },
       user: undefined,
@@ -558,9 +521,6 @@ describe("jwt callback - magic link fallback paths", () => {
   });
 });
 
-// ---------------------------------------------------------------------------
-// authConfig - structural assertions
-// ---------------------------------------------------------------------------
 describe("authConfig structure", () => {
   test("uses JWT session strategy", () => {
     expect(authConfig.session?.strategy).toBe("jwt");

--- a/services/frontend/__tests__/components/calendar/CalendarClient.test.tsx
+++ b/services/frontend/__tests__/components/calendar/CalendarClient.test.tsx
@@ -2,7 +2,6 @@ import { render, screen, fireEvent } from "@testing-library/react";
 import { CalendarClient } from "@/components/calendar/CalendarClient";
 import { JournalEntry } from "@/types/journal";
 
-// Mock child components to test orchestration
 jest.mock("@/components/calendar/CalendarHeader", () => ({
   CalendarHeader: ({
     currentMonth,
@@ -109,33 +108,28 @@ describe("CalendarClient", () => {
 
   it("shows current month in header", () => {
     render(<CalendarClient {...defaultProps} />);
-    // June 2025 -> month 6
     expect(screen.getByTestId("current-month")).toHaveTextContent("6/2025");
   });
 
   it("navigates to previous month", () => {
     render(<CalendarClient {...defaultProps} />);
     fireEvent.click(screen.getByText("Prev Month"));
-    // June -> May
     expect(screen.getByTestId("current-month")).toHaveTextContent("5/2025");
   });
 
   it("navigates to next month", () => {
     render(<CalendarClient {...defaultProps} />);
     fireEvent.click(screen.getByText("Next Month"));
-    // June -> July
     expect(screen.getByTestId("current-month")).toHaveTextContent("7/2025");
   });
 
   it("shows entries for the selected date", () => {
     render(<CalendarClient {...defaultProps} />);
-    // serverDate is 2025-06-15, which has 1 entry
     expect(screen.getByTestId("entry-count")).toHaveTextContent("1");
   });
 
   it("shows 0 entries for dates without journals", () => {
     render(<CalendarClient {...defaultProps} serverDate="2025-06-01" />);
-    // June 1 has no entries
     expect(screen.getByTestId("entry-count")).toHaveTextContent("0");
   });
 });

--- a/services/frontend/__tests__/components/calendar/CalendarGrid.test.tsx
+++ b/services/frontend/__tests__/components/calendar/CalendarGrid.test.tsx
@@ -90,7 +90,6 @@ describe("CalendarGrid", () => {
       avgMood: 7,
     });
     render(<CalendarGrid calendarDays={days} onDateSelect={jest.fn()} />);
-    // Day 6 button shows date "6" and "2 entries" and mood badge "7"
     const dayCell = screen.getByRole("button", { name: /2 entries/ });
     expect(dayCell).toHaveTextContent("7");
   });
@@ -126,7 +125,6 @@ describe("CalendarGrid", () => {
     const { container } = render(
       <CalendarGrid calendarDays={days} onDateSelect={jest.fn()} />,
     );
-    // Today dot is a small div with bg-lotus-500 rounded-full
     expect(
       container.querySelector(".bg-lotus-500.rounded-full"),
     ).toBeInTheDocument();

--- a/services/frontend/__tests__/components/calendar/CalendarHeader.test.tsx
+++ b/services/frontend/__tests__/components/calendar/CalendarHeader.test.tsx
@@ -9,7 +9,7 @@ jest.mock("lucide-react", () => ({
 
 describe("CalendarHeader", () => {
   const defaultProps = {
-    currentMonth: new Date(2025, 5, 1), // June 2025
+    currentMonth: new Date(2025, 5, 1),
     onNavigateMonth: jest.fn(),
     onGoToToday: jest.fn(),
     timezone: "UTC",
@@ -53,7 +53,6 @@ describe("CalendarHeader", () => {
     render(
       <CalendarHeader {...defaultProps} onNavigateMonth={onNavigateMonth} />,
     );
-    // ChevronLeft is the first navigation button
     const prevButton = screen.getByTestId("chevron-left").closest("button")!;
     fireEvent.click(prevButton);
     expect(onNavigateMonth).toHaveBeenCalledWith("prev");

--- a/services/frontend/__tests__/components/calendar/SelectedDateEntries.test.tsx
+++ b/services/frontend/__tests__/components/calendar/SelectedDateEntries.test.tsx
@@ -8,7 +8,6 @@ jest.mock("next/link", () => {
   );
 });
 
-// Mock JournalEntryCard since it's tested separately
 jest.mock("@/components/journal/JournalEntryCard", () => ({
   JournalEntryCard: ({ entry }: { entry: JournalEntry }) => (
     <div data-testid={`entry-card-${entry.journalId}`}>{entry.journalText}</div>
@@ -25,7 +24,7 @@ const mockEntry: JournalEntry = {
 
 describe("SelectedDateEntries", () => {
   describe("with a past date and no entries", () => {
-    const pastDate = new Date(2024, 0, 15); // Jan 15, 2024
+    const pastDate = new Date(2024, 0, 15);
 
     it("renders the formatted date", () => {
       render(
@@ -79,8 +78,8 @@ describe("SelectedDateEntries", () => {
   });
 
   describe("with a future date and no entries", () => {
-    // Use a date far in the future to ensure it's always future
-    const futureDate = new Date(2099, 11, 25); // Dec 25, 2099
+    // Far-future date so it stays "in the future" regardless of when the test runs.
+    const futureDate = new Date(2099, 11, 25);
 
     it("shows 'Future entries cannot be created' after effect", async () => {
       await act(async () => {

--- a/services/frontend/__tests__/components/journal/CreateJournalForm.test.tsx
+++ b/services/frontend/__tests__/components/journal/CreateJournalForm.test.tsx
@@ -1,7 +1,6 @@
 import { render, screen, fireEvent } from "@testing-library/react";
 import { CreateJournalForm } from "@/components/journal/CreateJournalForm";
 
-// Mock child components since they're tested separately
 jest.mock("@/components/journal/MoodSelector", () => ({
   MoodSlider: ({
     value,

--- a/services/frontend/__tests__/components/journal/JournalEntryCard.test.tsx
+++ b/services/frontend/__tests__/components/journal/JournalEntryCard.test.tsx
@@ -7,7 +7,7 @@ describe("JournalEntryCard", () => {
     journalId: "1",
     userId: "user-1",
     journalText: "A short journal entry.",
-    userMood: 7, // happy
+    userMood: 7,
     createdAt: "2025-06-15T14:30:00Z",
   };
 
@@ -15,7 +15,7 @@ describe("JournalEntryCard", () => {
     journalId: "2",
     userId: "user-1",
     journalText: "A".repeat(250),
-    userMood: 3, // sad
+    userMood: 3,
     createdAt: "2025-01-01T09:05:00Z",
   };
 
@@ -26,8 +26,7 @@ describe("JournalEntryCard", () => {
 
   it("renders the formatted date", () => {
     render(<JournalEntryCard entry={shortEntry} timezone="UTC" />);
-    // Date formatting is locale-dependent based on the component's custom formatter
-    // Just check that some date text is rendered
+    // Formatting uses a locale-dependent custom formatter; match any plausible date text.
     const dateElement = screen.getByText(/2025|June|January/i, {
       exact: false,
     });
@@ -36,13 +35,11 @@ describe("JournalEntryCard", () => {
 
   it("renders mood badge with label (1-10 scale)", () => {
     render(<JournalEntryCard entry={shortEntry} timezone="UTC" />);
-    // userMood 7 -> badge "Mood 7"
     expect(screen.getByText("Mood 7")).toBeInTheDocument();
   });
 
   it("renders sad mood correctly (low score)", () => {
     render(<JournalEntryCard entry={longEntry} timezone="UTC" />);
-    // userMood 3 -> badge "Mood 3"
     expect(screen.getByText("Mood 3")).toBeInTheDocument();
   });
 
@@ -54,7 +51,6 @@ describe("JournalEntryCard", () => {
 
     it("truncates text longer than 200 characters", () => {
       render(<JournalEntryCard entry={longEntry} timezone="UTC" />);
-      // Should show truncated text with "..."
       const displayedText = screen.getByText(/\.\.\.$/);
       expect(displayedText).toBeInTheDocument();
     });
@@ -67,16 +63,13 @@ describe("JournalEntryCard", () => {
     it("expands text when 'Read more' is clicked", () => {
       render(<JournalEntryCard entry={longEntry} timezone="UTC" />);
       fireEvent.click(screen.getByText("Read more"));
-      // Full text should now be visible (no "...")
       expect(screen.getByText("A".repeat(250))).toBeInTheDocument();
       expect(screen.getByText("Show less")).toBeInTheDocument();
     });
 
     it("collapses text when 'Show less' is clicked", () => {
       render(<JournalEntryCard entry={longEntry} timezone="UTC" />);
-      // Expand
       fireEvent.click(screen.getByText("Read more"));
-      // Collapse
       fireEvent.click(screen.getByText("Show less"));
       expect(screen.getByText("Read more")).toBeInTheDocument();
       expect(screen.queryByText("A".repeat(250))).not.toBeInTheDocument();

--- a/services/frontend/__tests__/components/journal/JournalHomeClient.test.tsx
+++ b/services/frontend/__tests__/components/journal/JournalHomeClient.test.tsx
@@ -94,7 +94,7 @@ function makeEntries(count: number): JournalEntry[] {
     journalId: String(i + 1),
     userId: "user-1",
     journalText: `Journal entry number ${i + 1}`,
-    userMood: 7, // happy
+    userMood: 7,
     createdAt: `2025-01-${String(i + 1).padStart(2, "0")}T10:00:00Z`,
   }));
 }
@@ -187,11 +187,9 @@ describe("JournalHomeClient", () => {
           timezone="UTC"
         />,
       );
-      // Go to page 2 first
       fireEvent.click(screen.getByText("Go to page 2"));
       expect(screen.getByTestId("current-page")).toHaveTextContent("2");
 
-      // Now set search — should reset to page 1
       fireEvent.click(screen.getByText("Set Search"));
       expect(screen.getByTestId("current-page")).toHaveTextContent("1");
     });
@@ -221,7 +219,6 @@ describe("JournalHomeClient", () => {
           timezone="UTC"
         />,
       );
-      // Activate a filter
       fireEvent.click(screen.getByText("Set Search"));
       expect(screen.getByText("Clear Filters")).toBeInTheDocument();
     });

--- a/services/frontend/__tests__/components/journal/JournalList.test.tsx
+++ b/services/frontend/__tests__/components/journal/JournalList.test.tsx
@@ -2,7 +2,6 @@ import { render, screen } from "@testing-library/react";
 import { JournalList } from "@/components/journal/JournalList";
 import { JournalEntry } from "@/types/journal";
 
-// Mock JournalEntryCard since it's tested separately
 jest.mock("@/components/journal/JournalEntryCard", () => ({
   JournalEntryCard: ({ entry }: { entry: JournalEntry }) => (
     <div data-testid={`journal-card-${entry.journalId}`}>

--- a/services/frontend/__tests__/components/journal/JournalPagination.test.tsx
+++ b/services/frontend/__tests__/components/journal/JournalPagination.test.tsx
@@ -103,7 +103,6 @@ describe("JournalPagination", () => {
   describe("page number buttons", () => {
     it("renders page number buttons", () => {
       render(<JournalPagination {...defaultProps} currentPage={1} />);
-      // Should show pages 1, 2, 3, ..., 5
       expect(screen.getByText("1")).toBeInTheDocument();
       expect(screen.getByText("2")).toBeInTheDocument();
       expect(screen.getByText("3")).toBeInTheDocument();

--- a/services/frontend/__tests__/components/journal/SuccessMessage.test.tsx
+++ b/services/frontend/__tests__/components/journal/SuccessMessage.test.tsx
@@ -1,7 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import { SuccessMessage } from "@/components/journal/SuccessMessage";
 
-// Mock lucide-react icons
 jest.mock("lucide-react", () => ({
   CheckCircle: ({ className }: { className?: string }) => (
     <svg data-testid="check-circle-icon" className={className} />

--- a/services/frontend/__tests__/components/landing/LandingPage.test.tsx
+++ b/services/frontend/__tests__/components/landing/LandingPage.test.tsx
@@ -1,28 +1,30 @@
-import { render, screen } from '@testing-library/react'
-import LandingPage from '@/components/landing/LandingPage' // Note: default import now
+import { render, screen } from "@testing-library/react";
+import LandingPage from "@/components/landing/LandingPage";
 
-// Mock Next.js Link component
-jest.mock('next/link', () => {
-    return ({ children, href }: { children: React.ReactNode; href: string }) => {
-        return <a href={href}>{children}</a>
-    }
-})
+jest.mock("next/link", () => {
+  return ({ children, href }: { children: React.ReactNode; href: string }) => {
+    return <a href={href}>{children}</a>;
+  };
+});
 
-describe('LandingPage', () => {
-    test('renders main heading', () => {
-        render(<LandingPage />)
-        expect(screen.getByText((content, element) => {
-            return element?.textContent === 'Your thoughts, organized and understood'
-        })).toBeInTheDocument()
-    })
+describe("LandingPage", () => {
+  test("renders main heading", () => {
+    render(<LandingPage />);
+    expect(
+      screen.getByText((content, element) => {
+        return (
+          element?.textContent === "Your thoughts, organized and understood"
+        );
+      }),
+    ).toBeInTheDocument();
+  });
 
-    test('renders feature cards', () => {
-        render(<LandingPage />)
+  test("renders feature cards", () => {
+    render(<LandingPage />);
 
-        expect(screen.getByText('Simple Writing')).toBeInTheDocument()
-        expect(screen.getByText('Daily Tracking')).toBeInTheDocument()
-        expect(screen.getByText('Mood Insights')).toBeInTheDocument()
-        expect(screen.getByText('Private & Secure')).toBeInTheDocument()
-    })
-
-})
+    expect(screen.getByText("Simple Writing")).toBeInTheDocument();
+    expect(screen.getByText("Daily Tracking")).toBeInTheDocument();
+    expect(screen.getByText("Mood Insights")).toBeInTheDocument();
+    expect(screen.getByText("Private & Secure")).toBeInTheDocument();
+  });
+});

--- a/services/frontend/__tests__/components/nav/Navbar.test.tsx
+++ b/services/frontend/__tests__/components/nav/Navbar.test.tsx
@@ -1,7 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import Navbar from "@/components/Navbar";
 
-// Mock auth
 jest.mock("@/auth", () => ({
   auth: jest.fn(),
 }));
@@ -89,7 +88,8 @@ describe("Navbar", () => {
     it("shows navigation links", async () => {
       const NavbarEl = await Navbar();
       render(NavbarEl);
-      expect(screen.getAllByText("Home")).toHaveLength(2); // desktop + mobile
+      // desktop + mobile layouts render each link once, so each appears twice.
+      expect(screen.getAllByText("Home")).toHaveLength(2);
       expect(screen.getAllByText("Journal")).toHaveLength(2);
       expect(screen.getAllByText("Calendar")).toHaveLength(2);
       expect(screen.getAllByText("Profile")).toHaveLength(2);
@@ -110,7 +110,6 @@ describe("Navbar", () => {
     it("renders mobile navigation", async () => {
       const NavbarEl = await Navbar();
       render(NavbarEl);
-      // Mobile nav has duplicate links
       const homeLinks = screen.getAllByText("Home");
       expect(homeLinks).toHaveLength(2);
     });

--- a/services/frontend/__tests__/components/profile/ProfileHeader.test.tsx
+++ b/services/frontend/__tests__/components/profile/ProfileHeader.test.tsx
@@ -53,7 +53,6 @@ describe("ProfileHeader", () => {
     await act(async () => {
       render(<ProfileHeader {...defaultProps} />);
     });
-    // After useEffect, should show "X days ago"
     expect(screen.getByText(/days ago/)).toBeInTheDocument();
   });
 

--- a/services/frontend/__tests__/components/profile/ProfileInsights.test.tsx
+++ b/services/frontend/__tests__/components/profile/ProfileInsights.test.tsx
@@ -21,7 +21,7 @@ describe("ProfileInsights", () => {
 
   it("renders mood badge for average mood (1-10 scale)", () => {
     render(<ProfileInsights {...defaultProps} />);
-    // Badge shows mood label (number); exact match avoids "7/10"
+    // Exact match avoids also matching the "7/10" text rendered elsewhere.
     expect(screen.getByText("7", { exact: true })).toBeInTheDocument();
   });
 
@@ -51,8 +51,7 @@ describe("ProfileInsights", () => {
     render(
       <ProfileInsights {...defaultProps} favoriteModCategory="Positive" />,
     );
-    // The component renders 😊 for Positive, plus we also get 😊 from the mood config
-    // Check the specific section
+    // 😊 appears both for the Positive category and in the mood config, so match any occurrence.
     const moodCategoryEmojis = screen.getAllByText("😊");
     expect(moodCategoryEmojis.length).toBeGreaterThanOrEqual(1);
   });

--- a/services/frontend/__tests__/components/profile/ProfilePageClient.test.tsx
+++ b/services/frontend/__tests__/components/profile/ProfilePageClient.test.tsx
@@ -2,7 +2,6 @@ import { render, screen } from "@testing-library/react";
 import { ProfilePageClient } from "@/components/profile/ProfilePageClient";
 import type { ProfileStats } from "@/lib/utils/profileStats";
 
-// Mock child components to test composition
 jest.mock("@/components/profile/ProfileHeader", () => ({
   ProfileHeader: ({ name, email }: { name: string; email: string }) => (
     <div data-testid="profile-header">

--- a/services/frontend/__tests__/hooks/useCreateJournal.test.ts
+++ b/services/frontend/__tests__/hooks/useCreateJournal.test.ts
@@ -1,14 +1,12 @@
 import { renderHook, act, waitFor } from "@testing-library/react";
 import { useCreateJournal } from "@/hooks/useCreateJournal";
 
-// Mock the server action
 const mockCreateJournal = jest.fn();
 jest.mock("@/actions/journals", () => ({
   createJournal: (...args: unknown[]) => mockCreateJournal(...args),
 }));
 
-// Mock next/navigation (already partially done in jest.setup.js, but we need
-// access to the mock router for assertions)
+// Overrides the partial next/navigation mock from jest.setup.js so we can capture push calls.
 const mockPush = jest.fn();
 jest.mock("next/navigation", () => ({
   useRouter: () => ({
@@ -196,7 +194,6 @@ describe("useCreateJournal", () => {
 
     const { result } = renderHook(() => useCreateJournal());
 
-    // First: trigger validation error
     await act(async () => {
       await result.current.handleSubmit({
         preventDefault: jest.fn(),
@@ -204,7 +201,6 @@ describe("useCreateJournal", () => {
     });
     expect(result.current.error).toBeTruthy();
 
-    // Second: submit with valid entry — error should be cleared
     act(() => {
       result.current.setEntry("Valid entry");
     });

--- a/services/frontend/__tests__/lib/analytics.test.ts
+++ b/services/frontend/__tests__/lib/analytics.test.ts
@@ -1,12 +1,7 @@
 import { trackEvent, getTimeOfDay, countWords } from "@/lib/analytics";
 
-// ---------------------------------------------------------------------------
-// trackEvent
-// ---------------------------------------------------------------------------
-
 describe("trackEvent", () => {
   afterEach(() => {
-    // Restore window.gtag between tests
     if (typeof window !== "undefined") {
       delete (window as unknown as Record<string, unknown>).gtag;
     }
@@ -45,10 +40,6 @@ describe("trackEvent", () => {
   });
 });
 
-// ---------------------------------------------------------------------------
-// getTimeOfDay
-// ---------------------------------------------------------------------------
-
 describe("getTimeOfDay", () => {
   afterEach(() => {
     jest.restoreAllMocks();
@@ -80,10 +71,6 @@ describe("getTimeOfDay", () => {
     expect(getTimeOfDay()).toBe(expected);
   });
 });
-
-// ---------------------------------------------------------------------------
-// countWords
-// ---------------------------------------------------------------------------
 
 describe("countWords", () => {
   it("counts words in a normal sentence", () => {

--- a/services/frontend/__tests__/lib/server/featureFlags.test.ts
+++ b/services/frontend/__tests__/lib/server/featureFlags.test.ts
@@ -1,11 +1,3 @@
-/**
- * Tests for lib/server/featureFlags.ts
- *
- * Verifies correct flag parsing, error handling, and that every request
- * includes the Authorization Bearer header required by the backend auth
- * middleware.
- */
-
 jest.mock("@/lib/config", () => ({
   BACKEND_URL: "http://backend:8080",
   BACKEND_API_KEY: "test-api-key",

--- a/services/frontend/__tests__/server/analytics.test.ts
+++ b/services/frontend/__tests__/server/analytics.test.ts
@@ -1,18 +1,9 @@
-/**
- * Tests for lib/server/analytics.ts
- *
- * Tests fetchUserAnalytics by mocking the journals fetcher and verifying
- * that analytics are correctly computed from raw journal entries.
- */
-
 import { JournalEntry } from "@/types/journal";
 
-// Mock the journals module so fetchUserAnalytics uses our test data
 jest.mock("@/lib/server/journals", () => ({
   fetchAllJournalsForUser: jest.fn(),
 }));
 
-// Must import after jest.mock
 import { fetchUserAnalytics } from "@/lib/server/analytics";
 import { fetchAllJournalsForUser } from "@/lib/server/journals";
 
@@ -29,9 +20,6 @@ afterEach(() => {
   jest.restoreAllMocks();
 });
 
-// ---------------------------------------------------------------------------
-// Fixtures
-// ---------------------------------------------------------------------------
 function makeJournal(
   overrides: Partial<JournalEntry> & { createdAt: string },
 ): JournalEntry {
@@ -74,9 +62,6 @@ const sampleJournals: JournalEntry[] = [
   }),
 ];
 
-// ---------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------
 describe("fetchUserAnalytics", () => {
   test("returns computed analytics from journals", async () => {
     mockFetchAll.mockResolvedValueOnce({
@@ -90,8 +75,8 @@ describe("fetchUserAnalytics", () => {
     expect(result).not.toBeNull();
     expect(result!.userId).toBe("u1");
     expect(result!.totalJournals).toBe(3);
-    expect(result!.positiveEntries).toBe(2); // mood 7 and 8
-    expect(result!.negativeEntries).toBe(1); // mood 3
+    expect(result!.positiveEntries).toBe(2);
+    expect(result!.negativeEntries).toBe(1);
     expect(result!.neutralEntries).toBe(0);
     expect(result!.minMoodScore).toBe(3);
     expect(result!.maxMoodScore).toBe(8);
@@ -137,7 +122,6 @@ describe("fetchUserAnalytics", () => {
 
     expect(result).not.toBeNull();
     expect(result!.totalJournals).toBe(4);
-    // The old journal is outside 30 days, so 30d count should be 3
     expect(result!.totalJournals30d).toBe(3);
   });
 
@@ -151,7 +135,6 @@ describe("fetchUserAnalytics", () => {
     const result = await fetchUserAnalytics("u1");
 
     expect(result).not.toBeNull();
-    // 3 consecutive days: today, yesterday, two days ago
     expect(result!.dailyStreak).toBe(3);
   });
 
@@ -165,7 +148,6 @@ describe("fetchUserAnalytics", () => {
     const result = await fetchUserAnalytics("u1");
 
     expect(result).not.toBeNull();
-    // 2 out of 3 are positive (mood >= 7)
     expect(result!.positivePercentage).toBeCloseTo(66.67, 1);
   });
 });

--- a/services/frontend/__tests__/server/journals.test.ts
+++ b/services/frontend/__tests__/server/journals.test.ts
@@ -1,11 +1,3 @@
-/**
- * Tests for lib/server/journals.ts
- *
- * These test the server-side data-fetching layer by mocking global fetch
- * and verifying correct URL construction, response transformation, error
- * handling, and that the Authorization header is always included.
- */
-
 jest.mock("@/lib/config", () => ({
   BACKEND_URL: "http://backend:8080",
   BACKEND_API_KEY: "test-api-key",
@@ -17,9 +9,6 @@ import {
   fetchAllJournalsForUser,
 } from "@/lib/server/journals";
 
-// ---------------------------------------------------------------------------
-// Setup: mock global fetch
-// ---------------------------------------------------------------------------
 const mockFetch = jest.fn();
 global.fetch = mockFetch;
 
@@ -32,9 +21,6 @@ afterEach(() => {
   jest.restoreAllMocks();
 });
 
-// ---------------------------------------------------------------------------
-// Fixtures
-// ---------------------------------------------------------------------------
 const backendJournals = [
   {
     journalId: "j1",
@@ -52,9 +38,6 @@ const backendJournals = [
   },
 ];
 
-// ---------------------------------------------------------------------------
-// fetchJournalsForUser
-// ---------------------------------------------------------------------------
 describe("fetchJournalsForUser", () => {
   test("returns transformed journals on successful response", async () => {
     mockFetch.mockResolvedValueOnce({
@@ -73,7 +56,7 @@ describe("fetchJournalsForUser", () => {
       expect.objectContaining({ method: "GET" }),
     );
     expect(result.journals).toHaveLength(2);
-    // userMood should be transformed from string to number
+    // userMood is returned by the backend as a string but is exposed as a number.
     expect(result.journals[0].userMood).toBe(7);
     expect(result.journals[1].userMood).toBe(3);
     expect(result.totalCount).toBe(2);
@@ -185,9 +168,6 @@ describe("fetchJournalsForUser", () => {
   });
 });
 
-// ---------------------------------------------------------------------------
-// fetchRecentJournals
-// ---------------------------------------------------------------------------
 describe("fetchRecentJournals", () => {
   test("returns just the journals array with default count of 5", async () => {
     mockFetch.mockResolvedValueOnce({
@@ -224,9 +204,6 @@ describe("fetchRecentJournals", () => {
   });
 });
 
-// ---------------------------------------------------------------------------
-// fetchAllJournalsForUser
-// ---------------------------------------------------------------------------
 describe("fetchAllJournalsForUser", () => {
   test("paginates with limit=100 until hasMore is false", async () => {
     mockFetch.mockResolvedValueOnce({

--- a/services/frontend/__tests__/server/profile.test.ts
+++ b/services/frontend/__tests__/server/profile.test.ts
@@ -1,13 +1,5 @@
-/**
- * Tests for lib/server/profile.ts
- *
- * Tests fetchProfileStats by mocking the journals fetcher and verifying
- * it delegates correctly to calculateProfileStats.
- */
-
 import { fetchProfilePageData, fetchProfileStats } from "@/lib/server/profile";
 
-// Mock the journals module that profile.ts depends on
 jest.mock("@/lib/server/journals", () => ({
   fetchAllJournalsForUser: jest.fn(),
 }));
@@ -17,9 +9,6 @@ const mockFetchAll = fetchAllJournalsForUser as jest.MockedFunction<
   typeof fetchAllJournalsForUser
 >;
 
-// ---------------------------------------------------------------------------
-// Fixtures
-// ---------------------------------------------------------------------------
 const mockJournals = [
   {
     journalId: "j1",
@@ -37,9 +26,6 @@ const mockJournals = [
   },
 ];
 
-// ---------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------
 describe("fetchProfileStats", () => {
   beforeEach(() => {
     jest.clearAllMocks();

--- a/services/frontend/__tests__/utils/calendar.test.ts
+++ b/services/frontend/__tests__/utils/calendar.test.ts
@@ -17,16 +17,15 @@ function makeEntry(overrides: Partial<JournalEntry> = {}): JournalEntry {
 }
 
 describe("calendar utils", () => {
-  // ── toLocalDateString ─────────────────────────────────────────────────
-
   describe("toLocalDateString", () => {
     test("formats date as YYYY-MM-DD", () => {
-      const date = new Date(2025, 5, 15); // June 15, 2025 (month is 0-indexed)
+      // Date month argument is 0-indexed; 5 = June.
+      const date = new Date(2025, 5, 15);
       expect(toLocalDateString(date)).toBe("2025-06-15");
     });
 
     test("pads single-digit month and day", () => {
-      const date = new Date(2025, 0, 5); // Jan 5
+      const date = new Date(2025, 0, 5);
       expect(toLocalDateString(date)).toBe("2025-01-05");
     });
 
@@ -40,8 +39,6 @@ describe("calendar utils", () => {
       expect(toLocalDateString(date)).toBe("2025-01-01");
     });
   });
-
-  // ── groupJournalsByDate ───────────────────────────────────────────────
 
   describe("groupJournalsByDate", () => {
     test("returns empty map for no journals", () => {
@@ -71,31 +68,25 @@ describe("calendar utils", () => {
     });
   });
 
-  // ── generateCalendarDays ──────────────────────────────────────────────
-
   describe("generateCalendarDays", () => {
     test("always generates exactly 42 days (6 weeks)", () => {
-      const month = new Date(2025, 5, 1); // June 2025
+      const month = new Date(2025, 5, 1);
       const days = generateCalendarDays(month, new Map(), null, "2025-06-15");
       expect(days).toHaveLength(42);
     });
 
     test("marks current month days correctly", () => {
-      // June 2025 starts on Sunday
       const month = new Date(2025, 5, 1);
       const days = generateCalendarDays(month, new Map(), null, "2025-06-15");
 
-      // First day should be June 1 (Sunday) and be in current month
       const june1 = days.find((d) => d.dateString === "2025-06-01");
       expect(june1).toBeDefined();
       expect(june1!.isCurrentMonth).toBe(true);
 
-      // June 30 should be in current month
       const june30 = days.find((d) => d.dateString === "2025-06-30");
       expect(june30).toBeDefined();
       expect(june30!.isCurrentMonth).toBe(true);
 
-      // July 1 should not be in current month
       const july1 = days.find((d) => d.dateString === "2025-07-01");
       expect(july1).toBeDefined();
       expect(july1!.isCurrentMonth).toBe(false);
@@ -148,7 +139,7 @@ describe("calendar utils", () => {
       const june15 = days.find((d) => d.dateString === "2025-06-15");
       expect(june15!.entryCount).toBe(2);
       expect(june15!.entries).toHaveLength(2);
-      expect(june15!.avgMood).toBe(6); // (8+4)/2 = 6
+      expect(june15!.avgMood).toBe(6);
     });
 
     test("days without entries have 0 entryCount and avgMood", () => {
@@ -165,7 +156,6 @@ describe("calendar utils", () => {
       const month = new Date(2025, 5, 1);
       const days = generateCalendarDays(month, new Map(), null, "2025-06-15");
 
-      // No day should be selected
       const anySelected = days.some((d) => d.isSelected);
       expect(anySelected).toBe(false);
     });

--- a/services/frontend/__tests__/utils/dashboard.test.ts
+++ b/services/frontend/__tests__/utils/dashboard.test.ts
@@ -23,8 +23,6 @@ function makeEntry(overrides: Partial<JournalEntry> = {}): JournalEntry {
 }
 
 describe("dashboard utils", () => {
-  // ── calculateEntriesThisWeek ──────────────────────────────────────────
-
   describe("calculateEntriesThisWeek", () => {
     test("returns 0 for no journals", () => {
       expect(calculateEntriesThisWeek([])).toBe(0);
@@ -43,8 +41,6 @@ describe("dashboard utils", () => {
     });
   });
 
-  // ── calculateStreak (delegates to profileStats.calculateCurrentStreak) ─
-
   describe("calculateStreak", () => {
     test("returns 0 for no journals", () => {
       expect(calculateStreak([])).toBe(0);
@@ -55,8 +51,6 @@ describe("dashboard utils", () => {
       expect(calculateStreak(entries)).toBe(1);
     });
   });
-
-  // ── calculateAverageMood ──────────────────────────────────────────────
 
   describe("calculateAverageMood", () => {
     test("returns 0 when no recent entries", () => {
@@ -92,8 +86,6 @@ describe("dashboard utils", () => {
     });
   });
 
-  // ── getSentimentFromMood ──────────────────────────────────────────────
-
   describe("getSentimentFromMood", () => {
     test('returns "Positive" for mood >= 7', () => {
       expect(getSentimentFromMood(7)).toBe("Positive");
@@ -111,8 +103,6 @@ describe("dashboard utils", () => {
       expect(getSentimentFromMood(1)).toBe("Negative");
     });
   });
-
-  // ── getSentimentFromMoodInt ───────────────────────────────────────────
 
   describe("getSentimentFromMoodInt", () => {
     test('returns "positive" for mood >= 7', () => {
@@ -139,8 +129,6 @@ describe("dashboard utils", () => {
     });
   });
 
-  // ── generateTitle ─────────────────────────────────────────────────────
-
   describe("generateTitle", () => {
     test("returns full text if 4 words or fewer", () => {
       expect(generateTitle("Hello world")).toBe("Hello world");
@@ -162,8 +150,6 @@ describe("dashboard utils", () => {
     });
   });
 
-  // ── formatAbsoluteDate ────────────────────────────────────────────────
-
   describe("formatAbsoluteDate", () => {
     test("returns YYYY-MM-DD format", () => {
       expect(formatAbsoluteDate("2025-06-15T14:30:00Z")).toBe("2025-06-15");
@@ -174,8 +160,6 @@ describe("dashboard utils", () => {
       expect(formatAbsoluteDate("2025-01-01T23:59:59Z")).toBe("2025-01-01");
     });
   });
-
-  // ── formatRelativeDate ────────────────────────────────────────────────
 
   describe("formatRelativeDate", () => {
     test('returns "Just now" for very recent dates', () => {
@@ -207,13 +191,10 @@ describe("dashboard utils", () => {
     test("returns locale date string for dates older than a week", () => {
       const old = "2020-01-15T12:00:00Z";
       const result = formatRelativeDate(old);
-      // Should not be "X days ago" — should be a full date
       expect(result).not.toContain("days ago");
       expect(result).not.toBe("Just now");
     });
   });
-
-  // ── formatRecentEntries ───────────────────────────────────────────────
 
   describe("formatRecentEntries", () => {
     test("returns empty array for no journals", () => {
@@ -260,9 +241,9 @@ describe("dashboard utils", () => {
 
     test("assigns correct sentiment per mood", () => {
       const entries = [
-        makeEntry({ journalId: "1", userMood: 8 }), // positive
-        makeEntry({ journalId: "2", userMood: 5 }), // neutral
-        makeEntry({ journalId: "3", userMood: 2 }), // negative
+        makeEntry({ journalId: "1", userMood: 8 }),
+        makeEntry({ journalId: "2", userMood: 5 }),
+        makeEntry({ journalId: "3", userMood: 2 }),
       ];
       const results = formatRecentEntries(entries, 3);
       expect(results[0].sentiment).toBe("positive");

--- a/services/frontend/__tests__/utils/journalFilters.test.ts
+++ b/services/frontend/__tests__/utils/journalFilters.test.ts
@@ -49,8 +49,6 @@ const sampleEntries: JournalEntry[] = [
 ];
 
 describe("journalFilters", () => {
-  // ── filterJournalsBySearch ────────────────────────────────────────────
-
   describe("filterJournalsBySearch", () => {
     test("returns all journals when search term is empty", () => {
       expect(filterJournalsBySearch(sampleEntries, "")).toHaveLength(5);
@@ -68,7 +66,6 @@ describe("journalFilters", () => {
 
     test("matches partial words", () => {
       const result = filterJournalsBySearch(sampleEntries, "day");
-      // "great day at the park" and "neutral kind of day"
       expect(result).toHaveLength(2);
     });
 
@@ -76,8 +73,6 @@ describe("journalFilters", () => {
       expect(filterJournalsBySearch(sampleEntries, "zzzzz")).toHaveLength(0);
     });
   });
-
-  // ── filterJournalsByMood ──────────────────────────────────────────────
 
   describe("filterJournalsByMood", () => {
     test('returns all journals when selectedMood is "all"', () => {
@@ -106,8 +101,6 @@ describe("journalFilters", () => {
       expect(result[0].journalId).toBe("4");
     });
   });
-
-  // ── filterJournalsByTag ───────────────────────────────────────────────
 
   describe("filterJournalsByTag", () => {
     const entriesWithTags: JournalEntry[] = [
@@ -154,11 +147,8 @@ describe("journalFilters", () => {
     });
   });
 
-  // ── filterJournals (combined) ─────────────────────────────────────────
-
   describe("filterJournals", () => {
     test("applies both search and mood filters", () => {
-      // Search for "day" (matches entries 1 and 5) + mood 7 (entry 1)
       const result = filterJournals(sampleEntries, "day", "7");
       expect(result).toHaveLength(1);
       expect(result[0].journalId).toBe("1");
@@ -169,7 +159,6 @@ describe("journalFilters", () => {
     });
 
     test("returns empty when filters are incompatible", () => {
-      // Search for "excited" (entry 3, mood 8) but filter mood to 1
       expect(filterJournals(sampleEntries, "excited", "1")).toHaveLength(0);
     });
 
@@ -196,8 +185,6 @@ describe("journalFilters", () => {
       );
     });
   });
-
-  // ── getUniqueTagsFromJournals ─────────────────────────────────────────
 
   describe("getUniqueTagsFromJournals", () => {
     test("returns empty array when no journals have topics", () => {
@@ -241,8 +228,6 @@ describe("journalFilters", () => {
     });
   });
 
-  // ── getUniqueMoodsFromJournals ────────────────────────────────────────
-
   describe("getUniqueMoodsFromJournals", () => {
     test("returns empty array for no journals", () => {
       expect(getUniqueMoodsFromJournals([])).toHaveLength(0);
@@ -250,7 +235,6 @@ describe("journalFilters", () => {
 
     test("extracts unique moods sorted by number (1-10 scale)", () => {
       const moods = getUniqueMoodsFromJournals(sampleEntries);
-      // Moods present: 1, 4, 5, 7, 8
       expect(moods).toHaveLength(5);
       expect(moods[0]).toEqual({ key: "1", label: "1" });
       expect(moods[4]).toEqual({ key: "8", label: "8" });

--- a/services/frontend/__tests__/utils/profileStats.test.ts
+++ b/services/frontend/__tests__/utils/profileStats.test.ts
@@ -43,8 +43,6 @@ function makeStreakEntries(days: number, endDateStr: string): JournalEntry[] {
 }
 
 describe("profileStats", () => {
-  // ── getUniqueDateStrings ──────────────────────────────────────────────
-
   describe("getUniqueDateStrings", () => {
     test("returns empty set for no journals", () => {
       expect(getUniqueDateStrings([]).size).toBe(0);
@@ -62,8 +60,6 @@ describe("profileStats", () => {
       expect(dates.has("2025-06-02")).toBe(true);
     });
   });
-
-  // ── calculateBasicCounts ──────────────────────────────────────────────
 
   describe("calculateBasicCounts", () => {
     test("returns zeros for empty array", () => {
@@ -83,7 +79,7 @@ describe("profileStats", () => {
 
     test("counts entries this week", () => {
       const now = new Date();
-      const recent = new Date(now.getTime() - 2 * 24 * 60 * 60 * 1000); // 2 days ago
+      const recent = new Date(now.getTime() - 2 * 24 * 60 * 60 * 1000);
       const old = new Date("2020-01-01");
       const entries = [
         makeEntry({ createdAt: recent.toISOString() }),
@@ -93,8 +89,6 @@ describe("profileStats", () => {
       expect(counts.thisWeek).toBe(1);
     });
   });
-
-  // ── calculateAverageMood ──────────────────────────────────────────────
 
   describe("calculateAverageMood", () => {
     test("returns 0 for no journals", () => {
@@ -117,8 +111,6 @@ describe("profileStats", () => {
     });
   });
 
-  // ── getFirstEntryDate ─────────────────────────────────────────────────
-
   describe("getFirstEntryDate", () => {
     test("returns null for no journals", () => {
       expect(getFirstEntryDate([])).toBeNull();
@@ -133,16 +125,13 @@ describe("profileStats", () => {
     });
   });
 
-  // ── getMostActiveDay ──────────────────────────────────────────────────
-
   describe("getMostActiveDay", () => {
     test('returns "No data" for empty array', () => {
       expect(getMostActiveDay([])).toBe("No data");
     });
 
     test("returns the day with the most entries", () => {
-      // Create 3 entries on a Monday, 1 on a Tuesday
-      // 2025-06-02 is a Monday, 2025-06-03 is a Tuesday
+      // 2025-06-02 is a Monday (3 entries), 2025-06-03 is a Tuesday (1 entry).
       const entries = [
         makeEntry({ createdAt: "2025-06-02T08:00:00Z" }),
         makeEntry({ createdAt: "2025-06-02T12:00:00Z" }),
@@ -152,8 +141,6 @@ describe("profileStats", () => {
       expect(getMostActiveDay(entries)).toBe("Monday");
     });
   });
-
-  // ── getFavoriteMoodCategory ───────────────────────────────────────────
 
   describe("getFavoriteMoodCategory", () => {
     test('returns "No data" for empty array', () => {
@@ -189,8 +176,6 @@ describe("profileStats", () => {
       expect(getFavoriteMoodCategory(entries)).toBe("Negative");
     });
   });
-
-  // ── calculateTotalWords ───────────────────────────────────────────────
 
   describe("calculateTotalWords", () => {
     test("returns 0 for no journals", () => {
@@ -232,8 +217,6 @@ describe("profileStats", () => {
     });
   });
 
-  // ── calculateCurrentStreak ────────────────────────────────────────────
-
   describe("calculateCurrentStreak", () => {
     test("returns 0 for no journals", () => {
       expect(calculateCurrentStreak([])).toBe(0);
@@ -274,8 +257,6 @@ describe("profileStats", () => {
     });
   });
 
-  // ── calculateLongestStreak ────────────────────────────────────────────
-
   describe("calculateLongestStreak", () => {
     test("returns 0 for no journals", () => {
       expect(calculateLongestStreak([])).toBe(0);
@@ -287,13 +268,11 @@ describe("profileStats", () => {
     });
 
     test("calculates longest streak from non-consecutive groups", () => {
+      // Two streaks separated by a gap: Jun 1-3 (3 days) and Jun 10-14 (5 days).
       const entries = [
-        // Streak of 3: Jun 1-3
         makeEntry({ journalId: "1", createdAt: "2025-06-01T12:00:00Z" }),
         makeEntry({ journalId: "2", createdAt: "2025-06-02T12:00:00Z" }),
         makeEntry({ journalId: "3", createdAt: "2025-06-03T12:00:00Z" }),
-        // Gap
-        // Streak of 5: Jun 10-14
         makeEntry({ journalId: "4", createdAt: "2025-06-10T12:00:00Z" }),
         makeEntry({ journalId: "5", createdAt: "2025-06-11T12:00:00Z" }),
         makeEntry({ journalId: "6", createdAt: "2025-06-12T12:00:00Z" }),
@@ -312,8 +291,6 @@ describe("profileStats", () => {
       expect(calculateLongestStreak(entries)).toBe(2);
     });
   });
-
-  // ── calculateProfileStats ─────────────────────────────────────────────
 
   describe("calculateProfileStats", () => {
     test("returns default values for empty journals", () => {
@@ -348,8 +325,8 @@ describe("profileStats", () => {
       ];
       const stats = calculateProfileStats(entries);
       expect(stats.totalEntries).toBe(2);
-      expect(stats.averageMood).toBe(6); // (7+5)/2 = 6
-      expect(stats.totalWords).toBe(6); // 3 + 3
+      expect(stats.averageMood).toBe(6);
+      expect(stats.totalWords).toBe(6);
       expect(stats.currentStreak).toBe(1);
       expect(stats.longestStreak).toBe(1);
     });
@@ -373,7 +350,6 @@ describe("profileStats", () => {
         }),
       ];
       const stats = calculateProfileStats(entries);
-      // (7+5+3)/3 = 5.0
       expect(stats.averageMood).toBe(5);
     });
   });

--- a/services/frontend/actions/journals.ts
+++ b/services/frontend/actions/journals.ts
@@ -90,7 +90,8 @@ export async function createJournal(
 
     const data = await response.json();
 
-    // Fetch the updated total count so the client can detect first-entry
+    // Re-read the total count so the client can special-case the user's very
+    // first entry (welcome state, onboarding analytics, etc.).
     let totalCount: number | undefined;
     try {
       const countResp = await fetch(
@@ -105,10 +106,9 @@ export async function createJournal(
         totalCount = parseInt(countData.totalCount, 10) || undefined;
       }
     } catch {
-      // Non-critical — analytics only; swallow silently
+      // Non-critical — analytics only; swallow silently.
     }
 
-    // Revalidate cached data on pages that display journals
     revalidatePath(ROUTES.home);
     revalidatePath(ROUTES.journal.home);
     revalidatePath(ROUTES.journal.calendar);

--- a/services/frontend/auth.ts
+++ b/services/frontend/auth.ts
@@ -340,9 +340,8 @@ export const authConfig: NextAuthConfig = {
       let backendUser = await fetchBackendUser(user.email, { skipCache: true });
 
       if (!backendUser) {
-        // Create the user in the Go backend.
-        // For email sign-ins we pass "email" as the oauth_provider value
-        // to distinguish them from GitHub-authenticated users.
+        // For email sign-ins we pass "email" as oauth_provider so the backend
+        // can distinguish them from GitHub-authenticated users.
         const providerLabel = isEmailProvider ? "email" : account?.provider;
         const createResult = await createUserInBackend(
           user.email,
@@ -366,7 +365,6 @@ export const authConfig: NextAuthConfig = {
         }
       }
 
-      // Attach backend fields to the NextAuth user object
       (user as User).backendId = backendUser.userId;
       (user as User).createdAt = backendUser.createdAt;
       (user as User).role = backendUser.role;

--- a/services/frontend/components/analytics/AnalyticsUserProperties.tsx
+++ b/services/frontend/components/analytics/AnalyticsUserProperties.tsx
@@ -23,10 +23,8 @@ export function AnalyticsUserProperties() {
       return;
     }
 
-    // Set user_id for cross-device tracking
     window.gtag("set", { user_id: session.user.id } as never);
 
-    // Compute days_since_signup
     let daysSinceSignup = 0;
     if (session.user.createdAt) {
       const signupDate = new Date(session.user.createdAt);

--- a/services/frontend/components/dashboard/LoggedInDashboard.tsx
+++ b/services/frontend/components/dashboard/LoggedInDashboard.tsx
@@ -40,12 +40,12 @@ export const LoggedInDashboard = ({
   showCommunityPulse,
   todayTogether = null,
 }: LoggedInDashboardProps) => {
-  // Derive display values from analytics (or use defaults for new users)
   const totalEntries = analytics?.totalJournals ?? 0;
   const entriesLast30Days = analytics?.totalJournals30d ?? 0;
   const currentStreak = analytics?.dailyStreak ?? 0;
   const activeDays = analytics?.activeDays ?? 0;
-  // Use all-time avg mood so it matches profile page (profile uses calculateAverageMood over all journals)
+  // Use the all-time average so this value matches the profile page, which
+  // computes avg mood across every journal (not just the last 30 days).
   const avgMood = analytics?.avgMoodScore ?? 0;
   const avgMoodRounded = avgMood ? Math.round(avgMood * 10) / 10 : 0;
   const positivePct = analytics?.positivePercentage ?? null;
@@ -54,7 +54,6 @@ export const LoggedInDashboard = ({
   const sentimentTrend =
     avgMood > 0 ? getSentimentFromMood(avgMood) : "No Data";
 
-  // Format recent entries for display
   const recentEntries: DashboardEntry[] = formatRecentEntries(
     recentJournals,
     3,

--- a/services/frontend/components/journal/JournalHomeClient.tsx
+++ b/services/frontend/components/journal/JournalHomeClient.tsx
@@ -75,7 +75,6 @@ export function JournalHomeClient({
   // §3c: search_used — fire when the user stops typing (debounce 800ms)
   const searchDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  // Extract unique moods and tags from journals
   const uniqueMoods = useMemo(
     () => getUniqueMoodsFromJournals(journals),
     [journals],
@@ -85,13 +84,13 @@ export function JournalHomeClient({
     [journals],
   );
 
-  // Determine if we're in active server-side search mode with results
   const isSemanticActive =
     searchMode === "semantic" && searchTerm.trim() !== "";
   const isKeywordActive = searchMode === "keyword" && searchTerm.trim() !== "";
   const isServerSearchActive = isSemanticActive || isKeywordActive;
 
-  // Filter journals by search, mood, and tag (exact mode or no search term)
+  // In server-search modes we use the ordered results from the backend; in
+  // "exact" mode we apply the local text/mood/tag filter.
   const filteredJournals = useMemo(() => {
     if (isSemanticActive) {
       const entries = semanticResults.map((r) => r.journal);
@@ -113,7 +112,6 @@ export function JournalHomeClient({
     keywordResults,
   ]);
 
-  // Build a map of relevance scores by journal ID for rendering
   const similarityScores = useMemo(() => {
     if (isSemanticActive) {
       return new Map(
@@ -129,7 +127,6 @@ export function JournalHomeClient({
   const hasActiveFilters =
     searchTerm.trim() !== "" || selectedMood !== "all" || selectedTag !== "all";
 
-  // Paginate filtered results
   const paginatedJournals = useMemo(() => {
     const startIndex = (currentPage - 1) * itemsPerPage;
     return filteredJournals.slice(startIndex, startIndex + itemsPerPage);
@@ -140,7 +137,6 @@ export function JournalHomeClient({
     : totalCount;
   const totalPages = Math.ceil(displayTotalCount / itemsPerPage);
 
-  // Trigger semantic search (debounced, cached in Redis on the backend)
   const triggerSemanticSearch = useCallback((query: string) => {
     if (semanticDebounceRef.current) {
       clearTimeout(semanticDebounceRef.current);
@@ -160,7 +156,6 @@ export function JournalHomeClient({
     }, 300);
   }, []);
 
-  // Trigger keyword search (debounced, cached in Redis on the backend)
   const triggerKeywordSearch = useCallback((query: string) => {
     if (keywordDebounceRef.current) {
       clearTimeout(keywordDebounceRef.current);
@@ -180,7 +175,6 @@ export function JournalHomeClient({
     }, 300);
   }, []);
 
-  // Reset to page 1 when filters change
   const handleSearchChange = useCallback(
     (term: string) => {
       setSearchTerm(term);
@@ -196,7 +190,6 @@ export function JournalHomeClient({
         }, 800);
       }
 
-      // Trigger server-side search when in semantic or keyword mode
       if (searchMode === "semantic") {
         triggerSemanticSearch(term);
       } else if (searchMode === "keyword") {

--- a/services/frontend/components/journal/JournalPagination.tsx
+++ b/services/frontend/components/journal/JournalPagination.tsx
@@ -20,16 +20,15 @@ export function JournalPagination({
   const startItem = (currentPage - 1) * itemsPerPage + 1;
   const endItem = Math.min(currentPage * itemsPerPage, totalItems);
 
-  // Generate page numbers to show
+  // Build a compact page list: first page, a window of +/- `delta` around the
+  // current page, last page, with "..." placeholders inserted for any gaps.
   const getVisiblePages = () => {
-    const delta = 2; // Show 2 pages on each side of current page
+    const delta = 2;
     const range = [];
     const rangeWithDots = [];
 
-    // Always show first page
     range.push(1);
 
-    // Add pages around current page
     for (
       let i = Math.max(2, currentPage - delta);
       i <= Math.min(totalPages - 1, currentPage + delta);
@@ -38,15 +37,12 @@ export function JournalPagination({
       range.push(i);
     }
 
-    // Always show last page (if more than 1 page)
     if (totalPages > 1) {
       range.push(totalPages);
     }
 
-    // Remove duplicates and sort
     const uniquePages = [...new Set(range)].sort((a, b) => a - b);
 
-    // Add dots where there are gaps
     for (let i = 0; i < uniquePages.length; i++) {
       rangeWithDots.push(uniquePages[i]);
 
@@ -62,15 +58,12 @@ export function JournalPagination({
 
   return (
     <div className="flex flex-col sm:flex-row items-center justify-between gap-4 mt-8 py-6 border-t border-dark-600">
-      {/* Results info */}
       <div className="text-sm text-muted-dark">
         Showing {startItem}-{endItem} of {totalItems} entries
         {hasFilters && <span className="ml-1">(filtered)</span>}
       </div>
 
-      {/* Pagination controls */}
       <div className="flex items-center gap-2">
-        {/* Previous button */}
         <button
           onClick={() => onPageChange(currentPage - 1)}
           disabled={currentPage === 1}
@@ -80,7 +73,6 @@ export function JournalPagination({
           Previous
         </button>
 
-        {/* Page numbers */}
         <div className="flex items-center gap-1">
           {visiblePages.map((page, index) => (
             <div key={index}>
@@ -102,7 +94,6 @@ export function JournalPagination({
           ))}
         </div>
 
-        {/* Next button */}
         <button
           onClick={() => onPageChange(currentPage + 1)}
           disabled={currentPage === totalPages}

--- a/services/frontend/e2e/authenticated.spec.ts
+++ b/services/frontend/e2e/authenticated.spec.ts
@@ -1,14 +1,9 @@
-/**
- * E2E tests for authenticated pages.
- *
- * These tests inject a NextAuth session cookie to simulate a logged-in user.
- * They require:
- *   - The frontend running at BASE_URL (default: http://localhost:3000)
- *   - The backend running at the configured BACKEND_URL
- *   - PostgreSQL with the test user seeded (or the backend returning
- *     empty data gracefully)
- *   - AUTH_SECRET env var matching the frontend's secret
- */
+// These tests inject a NextAuth session cookie to simulate a logged-in user.
+// They require:
+//   - Frontend running at BASE_URL (default: http://localhost:3000)
+//   - Backend running at the configured BACKEND_URL
+//   - Postgres with the test user seeded (or backend returning empty data gracefully)
+//   - AUTH_SECRET env var matching the frontend's secret
 import { test, expect } from "@playwright/test";
 import { authenticateContext, TEST_USER } from "./helpers/auth";
 
@@ -22,12 +17,9 @@ test.describe("Authenticated: Dashboard", () => {
   }) => {
     await page.goto("/");
 
-    // Should see the welcome greeting, NOT the landing page heading
     await expect(
       page.getByRole("heading", { name: /welcome back/i }),
     ).toBeVisible();
-
-    // Landing page heading should NOT be present
     await expect(
       page.getByRole("heading", { name: /your thoughts/i }),
     ).not.toBeVisible();
@@ -36,7 +28,6 @@ test.describe("Authenticated: Dashboard", () => {
   test("dashboard displays stat cards", async ({ page }) => {
     await page.goto("/");
 
-    // The four stat card titles from LoggedInDashboard.tsx
     await expect(page.getByText("Last 30 Days")).toBeVisible();
     await expect(
       page.getByText("Current Streak", { exact: true }),
@@ -75,7 +66,6 @@ test.describe("Authenticated: Navigation", () => {
   }) => {
     await page.goto("/");
 
-    // Desktop nav links
     await expect(
       page.getByRole("link", { name: "Home" }).first(),
     ).toBeVisible();
@@ -93,7 +83,6 @@ test.describe("Authenticated: Navigation", () => {
     await page.getByRole("link", { name: "Journal" }).first().click();
     await page.waitForURL("**/journal/home");
 
-    // Journal home page should show the journal header or list
     await expect(page.locator("body")).toContainText(/journal/i);
   });
 
@@ -103,7 +92,6 @@ test.describe("Authenticated: Navigation", () => {
     await page.getByRole("link", { name: "Calendar" }).first().click();
     await page.waitForURL("**/journal/calendar");
 
-    // Calendar page should show weekday headers
     await expect(page.getByText("Mon", { exact: true })).toBeVisible();
   });
 });
@@ -116,14 +104,12 @@ test.describe("Authenticated: Journal Create", () => {
   test("journal create page loads with the form", async ({ page }) => {
     await page.goto("/journal/create");
 
-    // Should see the text editor with its placeholder
     await expect(page.getByPlaceholder(/what's on your mind/i)).toBeVisible();
   });
 
   test("journal create page shows mood slider", async ({ page }) => {
     await page.goto("/journal/create");
 
-    // Mood is a 1-10 slider; label and range input should be visible
     await expect(
       page.getByText(/how are you feeling\? \(1-10\)/i),
     ).toBeVisible();
@@ -139,14 +125,12 @@ test.describe("Authenticated: Profile", () => {
   test("profile page loads with user info", async ({ page }) => {
     await page.goto("/profile");
 
-    // Should see the test user's name
     await expect(page.getByText(TEST_USER.name)).toBeVisible();
   });
 
   test("profile page shows stat cards", async ({ page }) => {
     await page.goto("/profile");
 
-    // Profile stats include these titles
     await expect(page.getByText("Total Entries")).toBeVisible();
   });
 });

--- a/services/frontend/e2e/csgodouble.spec.ts
+++ b/services/frontend/e2e/csgodouble.spec.ts
@@ -1,10 +1,5 @@
-/**
- * E2E tests for the CSGODouble game page.
- *
- * Access is gated by the `frontend_admin` waffle flag (superusers=true),
- * so only Admin-role users can view the page. Consumer users are
- * redirected to /profile.
- */
+// The CSGODouble page is gated by the frontend_admin waffle flag (superusers=true),
+// so only Admin-role users can view it. Consumer users are redirected to /profile.
 import { test, expect } from "@playwright/test";
 import {
   authenticateContext,
@@ -22,7 +17,6 @@ test.describe("CSGODouble: Consumer User (non-admin)", () => {
   }) => {
     await page.goto("/games/csgodouble");
 
-    // frontend_admin flag is superusers-only, so Consumer gets redirected to /profile
     await page.waitForURL("**/profile", { timeout: 10000 });
 
     await expect(
@@ -39,7 +33,6 @@ test.describe("CSGODouble: Admin User", () => {
   test("page loads with heading", async ({ page }) => {
     await page.goto("/games/csgodouble");
 
-    // Skip if admin flag isn't active (shouldn't happen, but safety)
     const heading = page.getByRole("heading", { name: /csgo double/i });
     test.skip(
       !(await heading.isVisible().catch(() => false)),
@@ -72,7 +65,7 @@ test.describe("CSGODouble: Admin User", () => {
     );
 
     await expect(balanceLabel).toBeVisible();
-    // Balance value (e.g. "$100") is the sibling <p> after the "Balance" label
+    // The balance value (e.g. "$100") renders as a sibling <p> of the label.
     const balanceValue = balanceLabel.locator("..").locator("p.text-2xl");
     await expect(balanceValue).toBeVisible();
     await expect(balanceValue).toHaveText(/^\$\d+$/);
@@ -81,7 +74,7 @@ test.describe("CSGODouble: Admin User", () => {
   test("countdown or spinning state is displayed", async ({ page }) => {
     await page.goto("/games/csgodouble");
 
-    // Either "Rolling in X.Xs" countdown, "Spinning…", or "Loading…" should show
+    // The status card can be in one of three states: countdown, spinning, or loading.
     const statusCard = page.locator("text=/rolling in|spinning|loading/i");
     test.skip(
       !(await statusCard.isVisible().catch(() => false)),
@@ -102,7 +95,7 @@ test.describe("CSGODouble: Admin User", () => {
 
     await expect(betInput).toBeVisible();
 
-    // Quick bet buttons (exact: true to avoid +1 matching +10, +100, +1000)
+    // exact: true prevents "+1" from matching "+10", "+100", "+1000".
     for (const label of ["Clear", "Last", "+1", "+10", "+100", "Max"]) {
       await expect(
         page.getByRole("button", { name: label, exact: true }),
@@ -119,13 +112,10 @@ test.describe("CSGODouble: Admin User", () => {
       "frontend_admin flag not active",
     );
 
-    // Red zone (1-7, 2x)
     await expect(redZone).toBeVisible();
-    // Green zone (0, 14x)
     await expect(
       page.getByRole("button", { name: "0" }).filter({ hasText: "14x" }),
     ).toBeVisible();
-    // Black zone (8-14, 2x)
     await expect(page.getByRole("button", { name: /8 to 14/i })).toBeVisible();
   });
 
@@ -138,27 +128,21 @@ test.describe("CSGODouble: Admin User", () => {
       "frontend_admin flag not active",
     );
 
-    // Read initial balance (scoped to the Balance label's parent)
+    // Scope to the Balance label's parent so we match the value, not any $-prefixed text.
     const balanceValue = page
       .getByText("Balance")
       .locator("..")
       .locator("p.text-2xl");
     const initialBalance = await balanceValue.textContent();
 
-    // Set bet amount to 10
     await betInput.fill("10");
 
-    // Place a bet on 1-7 (red zone)
     const redZone = page.getByRole("button", { name: /1 to 7/i });
     await redZone.click();
 
-    // The zone should show "Your bet: $10"
     await expect(page.getByText("Your bet: $10")).toBeVisible();
-
-    // Total placed should show 10
     await expect(page.getByText("Total placed this round: $10")).toBeVisible();
 
-    // Balance should have decreased
     const newBalance = await balanceValue.textContent();
     expect(newBalance).not.toEqual(initialBalance);
   });
@@ -172,40 +156,32 @@ test.describe("CSGODouble: Admin User", () => {
       "frontend_admin flag not active",
     );
 
-    // Read initial balance (scoped to the Balance label's parent)
+    // Scope to the Balance label's parent so we match the value, not any $-prefixed text.
     const balanceValue = page
       .getByText("Balance")
       .locator("..")
       .locator("p.text-2xl");
     const initialBalance = await balanceValue.textContent();
 
-    // Place a bet
     await betInput.fill("10");
     await page.getByRole("button", { name: /1 to 7/i }).click();
-
-    // Verify bet was placed
     await expect(page.getByText("Your bet: $10")).toBeVisible();
 
-    // Clear all bets
     await page.getByRole("button", { name: /clear all bets/i }).click();
 
-    // Balance should be restored
     await expect(balanceValue).toHaveText(initialBalance!);
-
-    // Total placed should be 0
     await expect(page.getByText("Total placed this round: $0")).toBeVisible();
   });
 
   test("roulette strip is rendered with colored cells", async ({ page }) => {
     await page.goto("/games/csgodouble");
 
-    // The roulette strip renders cells with bg-red-600, bg-zinc-900, bg-emerald-600
+    // Strip cells use bg-red-600 / bg-zinc-900 / bg-emerald-600 (red/black/green).
     const cells = page.locator(
       "[class*='bg-red-600'], [class*='bg-zinc-900'], [class*='bg-emerald-600']",
     );
     test.skip((await cells.count()) === 0, "frontend_admin flag not active");
 
-    // Should have multiple visible cells in the strip
     expect(await cells.count()).toBeGreaterThan(5);
   });
 });

--- a/services/frontend/e2e/journal-home.spec.ts
+++ b/services/frontend/e2e/journal-home.spec.ts
@@ -1,9 +1,5 @@
-/**
- * E2E tests for the journal home page basics.
- *
- * Tests run against the real backend with seeded data for the
- * Consumer test user (3 journal entries in bootstrap SQL).
- */
+// Runs against the real backend with the 3 journal entries seeded for the
+// Consumer test user in bootstrap SQL.
 import { test, expect } from "@playwright/test";
 import { authenticateContext } from "./helpers/auth";
 
@@ -19,7 +15,6 @@ test.describe("Journal Home: Page Structure", () => {
       page.getByRole("heading", { name: /my journal/i }),
     ).toBeVisible();
 
-    // Subtitle shows total count (seeded entries for the Consumer test user)
     await expect(page.getByText(/entries total/i)).toBeVisible();
   });
 
@@ -60,7 +55,6 @@ test.describe("Journal Home: Exact Search & Filters", () => {
     const searchInput = page.getByPlaceholder("Search your entries...");
     await searchInput.fill("learning");
 
-    // Filter summary should appear with the search term
     await expect(page.getByText(/showing \d+ of \d+ entries/i)).toBeVisible();
     await expect(page.getByText("Text: learning")).toBeVisible();
   });
@@ -71,16 +65,11 @@ test.describe("Journal Home: Exact Search & Filters", () => {
     const searchInput = page.getByPlaceholder("Search your entries...");
     await searchInput.fill("learning");
 
-    // Wait for filter summary to appear
     await expect(page.getByText(/showing \d+ of \d+ entries/i)).toBeVisible();
 
-    // Click clear filters
     await page.getByRole("button", { name: /clear filters/i }).click();
 
-    // Search input should be cleared
     await expect(searchInput).toHaveValue("");
-
-    // Filter summary should disappear
     await expect(
       page.getByText(/showing \d+ of \d+ entries/i),
     ).not.toBeVisible();
@@ -91,19 +80,16 @@ test.describe("Journal Home: Exact Search & Filters", () => {
   }) => {
     await page.goto("/journal/home");
 
-    // Select a non-default mood from the dropdown
     const moodSelect = page.locator("select").filter({ hasText: "All Moods" });
     const options = moodSelect.locator("option");
     const optionCount = await options.count();
 
-    // Only test if there are mood options beyond "All Moods"
+    // Only assert when the seeded user actually has at least one non-default mood.
     if (optionCount > 1) {
-      // Select the second option (first actual mood)
       const secondOption = await options.nth(1).getAttribute("value");
       if (secondOption) {
         await moodSelect.selectOption(secondOption);
 
-        // Filter summary should appear with mood badge
         await expect(
           page.getByText(/showing \d+ of \d+ entries/i),
         ).toBeVisible();
@@ -121,7 +107,6 @@ test.describe("Journal Home: Entry Display", () => {
   test("journal entries are displayed as cards", async ({ page }) => {
     await page.goto("/journal/home");
 
-    // Seeded entries should show mood badges
     const moodBadges = page.getByText(/mood \d/i);
     await expect(moodBadges.first()).toBeVisible();
   });
@@ -129,7 +114,6 @@ test.describe("Journal Home: Entry Display", () => {
   test("entries show date and mood information", async ({ page }) => {
     await page.goto("/journal/home");
 
-    // Each entry card has a mood badge
     const cards = page.locator("[class*='cursor-pointer']");
     const cardCount = await cards.count();
     expect(cardCount).toBeGreaterThan(0);

--- a/services/frontend/e2e/journal-search.spec.ts
+++ b/services/frontend/e2e/journal-search.spec.ts
@@ -1,13 +1,7 @@
-/**
- * E2E tests for feature-flag-gated search modes (keyword + semantic).
- *
- * Feature flags in seed data:
- *   - keyword_search: everyone=true  -> visible for all users
- *   - semantic_search: superusers=true -> visible for Admin only
- *
- * Tests use conditional skips when a flag isn't active so they remain
- * green regardless of backend flag state.
- */
+// Seeded feature flags gate the search modes:
+//   - keyword_search=everyone  -> visible for all users
+//   - semantic_search=superusers -> visible for Admin only
+// Tests use conditional skips so they stay green regardless of backend flag state.
 import { test, expect } from "@playwright/test";
 import {
   authenticateContext,
@@ -27,7 +21,6 @@ test.describe("Search Modes: Consumer User", () => {
 
     const keywordButton = page.getByRole("button", { name: "Keyword" });
 
-    // Skip if the flag isn't active for this user
     test.skip(
       !(await keywordButton.isVisible().catch(() => false)),
       "keyword_search flag not active for Consumer",
@@ -41,7 +34,6 @@ test.describe("Search Modes: Consumer User", () => {
   }) => {
     await page.goto("/journal/home");
 
-    // semantic_search is superusers-only, so Consumer should not see it
     await expect(
       page.getByRole("button", { name: "Semantic" }),
     ).not.toBeVisible();
@@ -79,7 +71,7 @@ test.describe("Search Modes: Consumer User", () => {
     const searchInput = page.getByPlaceholder("Keyword search your entries...");
     await searchInput.fill("walk");
 
-    // Wait for the debounced search and filter badge
+    // Generous timeout because the search input is debounced.
     await expect(page.getByText(/keyword: walk/i)).toBeVisible({
       timeout: 10000,
     });
@@ -96,13 +88,11 @@ test.describe("Search Modes: Consumer User", () => {
       "keyword_search flag not active",
     );
 
-    // Switch to keyword
     await keywordButton.click();
     await expect(
       page.getByPlaceholder("Keyword search your entries..."),
     ).toBeVisible();
 
-    // Switch back to exact
     await page.getByRole("button", { name: "Exact" }).click();
     await expect(page.getByPlaceholder("Search your entries...")).toBeVisible();
   });
@@ -121,7 +111,6 @@ test.describe("Search Modes: Admin User", () => {
     const keywordButton = page.getByRole("button", { name: "Keyword" });
     const semanticButton = page.getByRole("button", { name: "Semantic" });
 
-    // Skip if flags aren't active for Admin
     test.skip(
       !(await keywordButton.isVisible().catch(() => false)),
       "keyword_search flag not active for Admin",
@@ -179,7 +168,7 @@ test.describe("Search Modes: Admin User", () => {
     );
     await searchInput.fill("deployment");
 
-    // Wait for the debounced search and filter badge
+    // Generous timeout because the search input is debounced.
     await expect(page.getByText(/semantic: deployment/i)).toBeVisible({
       timeout: 10000,
     });
@@ -196,7 +185,6 @@ test.describe("Search Modes: Admin User", () => {
       "semantic_search flag not active",
     );
 
-    // Enter semantic search
     await semanticButton.click();
     const searchInput = page.getByPlaceholder(
       "Semantic search your entries...",
@@ -206,7 +194,7 @@ test.describe("Search Modes: Admin User", () => {
       timeout: 10000,
     });
 
-    // Switch back to exact — the text stays in the input but mode label changes
+    // Switching back to Exact keeps the input text but swaps the mode label.
     await page.getByRole("button", { name: "Exact" }).click();
     await expect(page.getByText(/text: deployment/i)).toBeVisible();
   });
@@ -230,10 +218,8 @@ test.describe("Search Modes: Admin User", () => {
       timeout: 10000,
     });
 
-    // Clear filters
     await page.getByRole("button", { name: /clear filters/i }).click();
 
-    // Search should be empty, filter summary gone
     await expect(
       page.getByText(/showing \d+ of \d+ entries/i),
     ).not.toBeVisible();

--- a/services/frontend/e2e/journal-tags.spec.ts
+++ b/services/frontend/e2e/journal-tags.spec.ts
@@ -1,12 +1,6 @@
-/**
- * E2E tests for topic tags on journal entries (gated by frontend_show_tags flag).
- *
- * Feature flag: frontend_show_tags (superusers=true -> Admin only)
- *
- * - Consumer user should NOT see the topic tag filter or tags on entries
- * - Admin user should see the topic tag filter and tags on entries
- *   (when the flag is active and entries have topics)
- */
+// Topic tags are gated behind frontend_show_tags (superusers-only, Admin in tests).
+// Consumer should see neither the tag filter nor tags on entries; Admin should see
+// both when the flag is active and entries have topics.
 import { test, expect } from "@playwright/test";
 import {
   authenticateContext,
@@ -22,7 +16,6 @@ test.describe("Journal Tags: Consumer User", () => {
   test("topic tag filter is NOT visible for Consumer", async ({ page }) => {
     await page.goto("/journal/home");
 
-    // The tag filter select has "All Topics" as its default option
     await expect(
       page.locator("select").filter({ hasText: "All Topics" }),
     ).not.toBeVisible();
@@ -33,7 +26,7 @@ test.describe("Journal Tags: Consumer User", () => {
   }) => {
     await page.goto("/journal/home");
 
-    // Topic tags are rendered in a container with aria-label="Topics"
+    // Topic tags render inside a container with aria-label="Topics".
     await expect(page.locator("[aria-label='Topics']")).not.toBeVisible();
   });
 });
@@ -48,7 +41,6 @@ test.describe("Journal Tags: Admin User", () => {
 
     const tagFilter = page.locator("select").filter({ hasText: "All Topics" });
 
-    // Skip if the flag isn't active
     test.skip(
       !(await tagFilter.isVisible().catch(() => false)),
       "frontend_show_tags flag not active for Admin",
@@ -66,7 +58,7 @@ test.describe("Journal Tags: Admin User", () => {
       "frontend_show_tags flag not active",
     );
 
-    // Select a tag option (the seeded topics: work, growth, wellbeing)
+    // Seeded topics for the Admin user are work/growth/wellbeing.
     const options = tagFilter.locator("option");
     const optionCount = await options.count();
 
@@ -75,10 +67,7 @@ test.describe("Journal Tags: Admin User", () => {
       if (secondOption) {
         await tagFilter.selectOption(secondOption);
 
-        // Filter badge should show "Topic: <tag>"
         await expect(page.getByText(/topic:/i)).toBeVisible();
-
-        // Filter summary should show filtered count
         await expect(
           page.getByText(/showing \d+ of \d+ entries/i),
         ).toBeVisible();
@@ -95,8 +84,7 @@ test.describe("Journal Tags: Admin User", () => {
       "frontend_show_tags flag not active",
     );
 
-    // Admin user's seeded entries have topics (work, growth, wellbeing)
-    // Topic tags are rendered in a container with aria-label="Topics"
+    // Admin's seeded entries have topics and render inside aria-label="Topics".
     const topicContainers = page.locator("[aria-label='Topics']");
     await expect(topicContainers.first()).toBeVisible();
   });
@@ -119,10 +107,8 @@ test.describe("Journal Tags: Admin User", () => {
         await tagFilter.selectOption(secondOption);
         await expect(page.getByText(/topic:/i)).toBeVisible();
 
-        // Clear filters
         await page.getByRole("button", { name: /clear filters/i }).click();
 
-        // Tag badge should be gone
         await expect(page.getByText(/topic:/i)).not.toBeVisible();
       }
     }

--- a/services/frontend/e2e/landing.spec.ts
+++ b/services/frontend/e2e/landing.spec.ts
@@ -1,16 +1,11 @@
-/**
- * E2E tests for the landing page (unauthenticated visitors).
- *
- * These tests do NOT require a running backend — the landing page
- * is entirely static and rendered for unauthenticated users.
- */
+// The landing page is fully static and rendered for unauthenticated users,
+// so these tests don't require a running backend.
 import { test, expect } from "@playwright/test";
 
 test.describe("Landing Page", () => {
   test("shows the landing page for unauthenticated users", async ({ page }) => {
     await page.goto("/");
 
-    // The main heading should be visible
     await expect(
       page.getByRole("heading", { name: /your thoughts/i }),
     ).toBeVisible();
@@ -33,7 +28,6 @@ test.describe("Landing Page", () => {
   test("shows feature cards", async ({ page }) => {
     await page.goto("/");
 
-    // The four feature titles from LandingPage.tsx
     const features = [
       "Simple Writing",
       "Daily Tracking",
@@ -50,7 +44,6 @@ test.describe("Landing Page", () => {
   }) => {
     await page.goto("/");
 
-    // LoginButton renders a Link (anchor) containing "Login"
     await expect(page.getByRole("link", { name: /login/i })).toBeVisible();
   });
 


### PR DESCRIPTION
## Description

Sweep across all services to remove AI-generated narration comments (restating the next line, test-structure markers, redundant docstrings) while preserving comments that explain non-obvious intent or trade-offs.

### Updated

- Backend, analyzer, django, dagster, experiments: strip `Arrange/Act/Assert`, `# Verify ...`, and other low-value narration from source and tests
- Frontend: trim JSDoc headers and narration across `actions/`, `components/`, `__tests__/`, and `e2e/` specs
- Bind loop variables in `train_article_recommender` lambdas to satisfy ruff `B023`