### PR TITLE
chore(backend): add k6 load test regression check

### DIFF
--- a/.github/workflows/backend.yaml
+++ b/.github/workflows/backend.yaml
@@ -78,6 +78,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: backend-pipeline
     name: Load Tests
+    env:
+      BACKEND_API_KEY: lotus-backend-dev-key
+      ANALYZER_API_KEY: lotus-analyzer-dev-key
 
     steps:
       - name: Checkout code
@@ -91,17 +94,30 @@ jobs:
           sparse-checkout-cone-mode: false
 
       - name: Start backend stack
-        env:
-          BACKEND_API_KEY: lotus-backend-dev-key
-          ANALYZER_API_KEY: lotus-analyzer-dev-key
         run: |
           docker compose -f docker/docker-compose-k6.yaml --profile load-test up -d --build --wait postgres redis django backend
 
       - name: Run k6 HTTP smoke test
-        env:
-          BACKEND_API_KEY: lotus-backend-dev-key
         run: |
           docker compose -f docker/docker-compose-k6.yaml --profile load-test run k6 run /scripts/http-gateway-load.js
+
+      # Ensures global http_req_duration thresholds still trip when one hot path
+      # is slow (see LOADTEST_DELAY_RANDOM_STRING_MS in services/backend/internal/main.go).
+      - name: Verify k6 fails under artificial delay
+        if: success()
+        env:
+          LOADTEST_DELAY_RANDOM_STRING_MS: "700"
+        run: |
+          docker compose -f docker/docker-compose-k6.yaml --profile load-test up -d --no-deps --force-recreate backend
+          set +e
+          docker compose -f docker/docker-compose-k6.yaml --profile load-test run k6 run /scripts/http-gateway-load.js
+          k6_exit=$?
+          set -e
+          if [ "$k6_exit" -eq 0 ]; then
+            echo "Expected k6 to exit non-zero (latency thresholds should fail with 700ms delay on /v1/util/random-string)."
+            exit 1
+          fi
+          echo "k6 exited $k6_exit as expected under artificial delay."
 
       - name: Backend logs
         if: failure()

--- a/docker/docker-compose-k6.yaml
+++ b/docker/docker-compose-k6.yaml
@@ -77,6 +77,7 @@ services:
       - BACKEND_API_KEY=${BACKEND_API_KEY:-lotus-backend-dev-key}
       - ANALYZER_API_KEY=${ANALYZER_API_KEY:-lotus-analyzer-dev-key}
       - REDIS_URL=redis://redis:6379
+      - LOADTEST_DELAY_RANDOM_STRING_MS=${LOADTEST_DELAY_RANDOM_STRING_MS:-}
     depends_on:
       postgres:
         condition: service_healthy

--- a/services/backend/internal/main.go
+++ b/services/backend/internal/main.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strconv"
 	"sync"
 	"syscall"
 	"time"
@@ -68,6 +69,27 @@ func authMiddleware(apiKey string, logger *slog.Logger, h http.Handler) http.Han
 			)
 			http.Error(w, `{"code":16,"message":"unauthorized"}`, http.StatusUnauthorized)
 			return
+		}
+		h.ServeHTTP(w, r)
+	})
+}
+
+const loadTestRandomStringPath = "/v1/util/random-string"
+
+// loadTestRandomStringDelay sleeps before handling the util random-string HTTP
+// route when LOADTEST_DELAY_RANDOM_STRING_MS is set (>0). Used to verify k6
+// latency thresholds against a single slow endpoint. Placed after auth so
+// unauthenticated readiness checks still receive a quick 401.
+func loadTestRandomStringDelay(logger *slog.Logger, h http.Handler) http.Handler {
+	ms, err := strconv.Atoi(os.Getenv("LOADTEST_DELAY_RANDOM_STRING_MS"))
+	if err != nil || ms <= 0 {
+		return h
+	}
+	d := time.Duration(ms) * time.Millisecond
+	logger.Info("LOADTEST_DELAY_RANDOM_STRING_MS is set; adding artificial delay to "+loadTestRandomStringPath, "delay", d)
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == loadTestRandomStringPath {
+			time.Sleep(d)
 		}
 		h.ServeHTTP(w, r)
 	})
@@ -292,7 +314,7 @@ func main() {
 	httpServer := &http.Server{
 		Addr:              ":8080",
 		ReadHeaderTimeout: 10 * time.Second,
-		Handler:           rateLimitMiddleware(ctx, 20, 40, allowCORS(corsOrigin, authMiddleware(backendAPIKey, logger, otelhttp.NewHandler(rootMux, "http")))),
+		Handler:           rateLimitMiddleware(ctx, 20, 40, allowCORS(corsOrigin, authMiddleware(backendAPIKey, logger, loadTestRandomStringDelay(logger, otelhttp.NewHandler(rootMux, "http"))))),
 	}
 
 	g, gCtx := errgroup.WithContext(ctx)


### PR DESCRIPTION
## Description

Adds an env-gated artificial delay on `GET /v1/util/random-string` for local or compose-based load testing, and extends the k6 CI job so a second run proves global latency thresholds still fail when that path is slow. Compose forwards the delay variable into the backend container; k6 job env keys are consolidated at the job level.

### Added

- `LOADTEST_DELAY_RANDOM_STRING_MS` HTTP middleware (backend) and compose passthrough for k6 stack
- CI step that recreates the backend with delay and asserts k6 exits non-zero

### Updated

- `.github/workflows/backend.yaml` (k6-smoke job env + verification step)

### Deleted

- None