### PR TITLE
feat(dbt): add sqlfluff checks in ci and pre-commit

### DIFF
--- a/.github/workflows/quality-sql.yaml
+++ b/.github/workflows/quality-sql.yaml
@@ -1,0 +1,53 @@
+name: SQL Quality Checks
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "services/dbt/**"
+      - ".github/workflows/quality-sql.yaml"
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "services/dbt/**"
+      - ".github/workflows/quality-sql.yaml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  UV_VERSION: "0.11.8"
+  PYTHON_VERSION: "3.13"
+
+jobs:
+  sqlfluff:
+    name: SQLFluff
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          version: ${{ env.UV_VERSION }}
+          python-version: ${{ env.PYTHON_VERSION }}
+          enable-cache: true
+          cache-dependency-glob: services/dbt/uv.lock
+          working-directory: services/dbt
+
+      - name: Install dependencies
+        working-directory: services/dbt
+        run: uv sync --locked --all-groups
+
+      - name: SQLFluff lint
+        working-directory: services/dbt
+        run: >
+          uv run sqlfluff lint models macros
+          --templater jinja
+          --format github-annotation-native
+          --annotation-level failure
+          --disable-progress-bar

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,11 +36,13 @@ repos:
       - id: check-yaml
       - id: check-added-large-files
 
-  # Shell script linting
-  - repo: https://github.com/koalaman/shellcheck-precommit
-    rev: v0.11.0
+  # Shell script linting (shellcheck-py bundles the binary; avoids Docker)
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.11.0.1
     hooks:
       - id: shellcheck
+        # Curl snippet collections, not executable shell scripts
+        exclude: ^services/(analyzer|backend)/resources/.*\.sh$
 
   # Go linters & formatters
   - repo: https://github.com/dnephin/pre-commit-golang
@@ -60,14 +62,18 @@ repos:
       # deadcode traces all reachable symbols from main + test entry points and flags unexported functions/types with no callers
       - id: go-deadcode
         name: deadcode (backend)
-        entry: bash -c 'cd services/backend && $(go env GOPATH)/bin/deadcode -test ./...'
+        entry:
+          bash -c 'cd services/backend && $(go env GOPATH)/bin/deadcode -test
+          ./...'
         language: system
         files: ^services/backend/.*\.go$
         pass_filenames: false
       # golangci-lint runs a comprehensive suite of linters (gosec, gocritic, staticcheck, etc.)
       - id: golangci-lint
         name: golangci-lint (backend)
-        entry: bash -c 'cd services/backend && $(go env GOPATH)/bin/golangci-lint run ./...'
+        entry:
+          bash -c 'cd services/backend && $(go env GOPATH)/bin/golangci-lint run
+          ./...'
         language: system
         files: ^services/backend/.*\.go$
         pass_filenames: false
@@ -85,10 +91,8 @@ repos:
     hooks:
       - id: yamllint
         args:
-          [
-            -d,
-            "{extends: default, rules: {document-start: disable, line-length: disable}}",
-          ]
+          - -d
+          - "{extends: default, rules: {document-start: disable, line-length: disable}}"
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.15.6
@@ -98,6 +102,12 @@ repos:
 
   - repo: local
     hooks:
+      - id: sqlfluff-dbt-fix
+        name: SQLFluff fix (dbt)
+        entry: scripts/sqlfluff-dbt-fix.sh
+        language: system
+        files: ^services/dbt/.*\.sql$
+        exclude: ^services/dbt/(target|dbt_packages)/
       - id: lint-bruno
         name: Bruno auth lint
         entry: bash scripts/lint-bruno.sh
@@ -126,7 +136,9 @@ repos:
         pass_filenames: false
       - id: dbt-source-schema-sync
         name: dbt source schema sync (django)
-        entry: bash -c 'make generate-dbt-source-schema && git diff --exit-code -- docker/db/generated/ci_source_schema.sql'
+        entry:
+          bash -c 'make generate-dbt-source-schema && git diff --exit-code --
+          docker/db/generated/ci_source_schema.sql'
         language: system
         stages: [pre-push]
         files: ^(services/django/|services/dbt/models/sources/application_db/)

--- a/scripts/sqlfluff-dbt-fix.sh
+++ b/scripts/sqlfluff-dbt-fix.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Git/IDE often invoke hooks with a minimal PATH; uv is typically in ~/.local/bin.
+export PATH="$HOME/.local/bin:$HOME/.cargo/bin:$PATH"
+
+if ! command -v uv >/dev/null 2>&1; then
+  echo "uv is required to run SQLFluff. Install uv or add it to PATH." >&2
+  exit 1
+fi
+
+dbt_files=()
+for path in "$@"; do
+  [[ "$path" == *.sql ]] || continue
+  [[ "$path" == services/dbt/* ]] || continue
+  [[ "$path" == services/dbt/target/* ]] && continue
+  [[ "$path" == services/dbt/dbt_packages/* ]] && continue
+  dbt_files+=("${path#services/dbt/}")
+done
+
+if [ "${#dbt_files[@]}" -eq 0 ]; then
+  exit 0
+fi
+
+cd services/dbt
+UV_CACHE_DIR="${UV_CACHE_DIR:-/tmp/uv-cache}" uv run sqlfluff fix \
+  --templater jinja \
+  --disable-progress-bar \
+  "${dbt_files[@]}"

--- a/services/dbt/models/gold/analytics/user_game_summary.sql
+++ b/services/dbt/models/gold/analytics/user_game_summary.sql
@@ -64,7 +64,7 @@ bet_streaks as (
         is_win,
         bet_created_at,
         row_number() over (partition by user_id order by bet_created_at)
-            - row_number() over (partition by user_id, is_win order by bet_created_at) as streak_group
+        - row_number() over (partition by user_id, is_win order by bet_created_at) as streak_group
     from bets
 ),
 
@@ -74,7 +74,10 @@ streak_lengths as (
         is_win,
         count(*) as streak_length
     from bet_streaks
-    group by user_id, is_win, streak_group
+    group by
+        user_id,
+        is_win,
+        streak_group
 ),
 
 max_streaks as (
@@ -94,11 +97,15 @@ zone_ranks as (
         count(*) as zone_count,
         row_number() over (partition by user_id order by count(*) desc) as rn
     from bets
-    group by user_id, bet_zone
+    group by
+        user_id,
+        bet_zone
 ),
 
 favorite_zone as (
-    select user_id, bet_zone as favorite_zone
+    select
+        user_id,
+        bet_zone as favorite_zone
     from zone_ranks
     where rn = 1
 ),
@@ -109,29 +116,29 @@ final as (
         users.user_email,
 
         -- all-time metrics
-        coalesce(m.total_bets, 0) as total_bets,
-        coalesce(m.total_wins, 0) as total_wins,
-        coalesce(m.total_losses, 0) as total_losses,
+        coalesce(user_bet_metrics.total_bets, 0) as total_bets,
+        coalesce(user_bet_metrics.total_wins, 0) as total_wins,
+        coalesce(user_bet_metrics.total_losses, 0) as total_losses,
         round(
-            coalesce(m.total_wins, 0)::numeric /
-            nullif(coalesce(m.total_bets, 0), 0) * 100,
+            coalesce(user_bet_metrics.total_wins, 0)::numeric
+            / nullif(coalesce(user_bet_metrics.total_bets, 0), 0) * 100,
             2
         ) as win_rate,
-        coalesce(m.total_wagered, 0) as total_wagered,
-        coalesce(m.total_payouts, 0) as total_payouts,
-        coalesce(m.net_profit, 0) as net_profit,
-        round(m.avg_bet_amount::numeric, 2) as avg_bet_amount,
-        coalesce(m.biggest_payout, 0) as biggest_payout,
-        coalesce(m.biggest_win, 0) as biggest_win,
-        coalesce(m.biggest_loss, 0) as biggest_loss,
+        coalesce(user_bet_metrics.total_wagered, 0) as total_wagered,
+        coalesce(user_bet_metrics.total_payouts, 0) as total_payouts,
+        coalesce(user_bet_metrics.net_profit, 0) as net_profit,
+        round(user_bet_metrics.avg_bet_amount::numeric, 2) as avg_bet_amount,
+        coalesce(user_bet_metrics.biggest_payout, 0) as biggest_payout,
+        coalesce(user_bet_metrics.biggest_win, 0) as biggest_win,
+        coalesce(user_bet_metrics.biggest_loss, 0) as biggest_loss,
 
         -- zone breakdown
-        coalesce(m.green_bets, 0) as green_bets,
-        coalesce(m.red_bets, 0) as red_bets,
-        coalesce(m.black_bets, 0) as black_bets,
-        coalesce(m.green_wins, 0) as green_wins,
-        coalesce(m.red_wins, 0) as red_wins,
-        coalesce(m.black_wins, 0) as black_wins,
+        coalesce(user_bet_metrics.green_bets, 0) as green_bets,
+        coalesce(user_bet_metrics.red_bets, 0) as red_bets,
+        coalesce(user_bet_metrics.black_bets, 0) as black_bets,
+        coalesce(user_bet_metrics.green_wins, 0) as green_wins,
+        coalesce(user_bet_metrics.red_wins, 0) as red_wins,
+        coalesce(user_bet_metrics.black_wins, 0) as black_wins,
 
         favorite_zone.favorite_zone,
 
@@ -140,32 +147,32 @@ final as (
         coalesce(max_streaks.longest_loss_streak, 0) as longest_loss_streak,
 
         -- 30d metrics
-        coalesce(m30.total_bets_30d, 0) as total_bets_30d,
-        coalesce(m30.total_wins_30d, 0) as total_wins_30d,
+        coalesce(user_bet_metrics_30d.total_bets_30d, 0) as total_bets_30d,
+        coalesce(user_bet_metrics_30d.total_wins_30d, 0) as total_wins_30d,
         round(
-            coalesce(m30.total_wins_30d, 0)::numeric /
-            nullif(coalesce(m30.total_bets_30d, 0), 0) * 100,
+            coalesce(user_bet_metrics_30d.total_wins_30d, 0)::numeric
+            / nullif(coalesce(user_bet_metrics_30d.total_bets_30d, 0), 0) * 100,
             2
         ) as win_rate_30d,
-        coalesce(m30.total_wagered_30d, 0) as total_wagered_30d,
-        coalesce(m30.net_profit_30d, 0) as net_profit_30d,
+        coalesce(user_bet_metrics_30d.total_wagered_30d, 0) as total_wagered_30d,
+        coalesce(user_bet_metrics_30d.net_profit_30d, 0) as net_profit_30d,
 
         -- balance
         balances.current_balance,
 
         -- timestamps
-        m.first_bet_at,
-        m.last_bet_at,
+        user_bet_metrics.first_bet_at,
+        user_bet_metrics.last_bet_at,
 
         case
-            when m.last_bet_at is not null
-            then current_date - date_trunc('day', m.last_bet_at)::date
+            when user_bet_metrics.last_bet_at is not null
+                then current_date - date_trunc('day', user_bet_metrics.last_bet_at)::date
             else null
         end as days_since_last_bet
 
     from users
-    left join user_bet_metrics m on users.user_id = m.user_id
-    left join user_bet_metrics_30d m30 on users.user_id = m30.user_id
+    left join user_bet_metrics on users.user_id = user_bet_metrics.user_id
+    left join user_bet_metrics_30d on users.user_id = user_bet_metrics_30d.user_id
     left join max_streaks on users.user_id = max_streaks.user_id
     left join favorite_zone on users.user_id = favorite_zone.user_id
     left join balances on users.user_id = balances.user_id

--- a/services/dbt/models/gold/analytics/user_journal_summary.sql
+++ b/services/dbt/models/gold/analytics/user_journal_summary.sql
@@ -63,28 +63,37 @@ user_metrics_30d as (
 -- topic metrics per user
 user_topic_metrics as (
     select
-        je.user_id,
-        count(distinct t.topic_name) as distinct_topics,
-        avg(t.topic_confidence) as avg_topic_confidence
-    from topics t
-    inner join journal_entries je on t.journal_id = je.journal_id
-    group by je.user_id
+        journal_entries.user_id,
+        count(distinct topics.topic_name) as distinct_topics,
+        avg(topics.topic_confidence) as avg_topic_confidence
+    from topics
+    inner join journal_entries on topics.journal_id = journal_entries.journal_id
+    group by journal_entries.user_id
 ),
 
 -- dominant topic per user
 topic_ranks as (
     select
-        je.user_id,
-        t.topic_name,
+        journal_entries.user_id,
+        topics.topic_name,
         count(*) as cnt,
-        row_number() over (partition by je.user_id order by count(*) desc, avg(t.topic_confidence) desc) as rn
-    from topics t
-    inner join journal_entries je on t.journal_id = je.journal_id
-    group by je.user_id, t.topic_name
+        row_number() over (
+            partition by journal_entries.user_id
+            order by
+                count(*) desc,
+                avg(topics.topic_confidence) desc
+        ) as rn
+    from topics
+    inner join journal_entries on topics.journal_id = journal_entries.journal_id
+    group by
+        journal_entries.user_id,
+        topics.topic_name
 ),
 
 dominant_topic as (
-    select user_id, topic_name as dominant_topic
+    select
+        user_id,
+        topic_name as dominant_topic
     from topic_ranks
     where rn = 1
 ),
@@ -114,7 +123,9 @@ current_streaks as (
         min(entry_date) as streak_start,
         max(entry_date) as streak_end
     from streaks
-    group by user_id, streak_group
+    group by
+        user_id,
+        streak_group
 ),
 
 active_streaks as (
@@ -184,27 +195,31 @@ final as (
 
         -- Calculated fields
         round(
-            coalesce(user_metrics.positive_entries, 0)::numeric /
-            nullif(coalesce(user_metrics.total_journals, 0), 0) * 100,
+            coalesce(user_metrics.positive_entries, 0)::numeric
+            / nullif(coalesce(user_metrics.total_journals, 0), 0) * 100,
             2
         ) as positive_percentage,
 
         case
             when user_metrics.last_journal_at is not null
-            then current_date - date_trunc('day', user_metrics.last_journal_at)::date
+                then current_date - date_trunc('day', user_metrics.last_journal_at)::date
             else null
         end as days_since_last_journal,
 
         case
-            when user_metrics.first_journal_at is not null
+            when
+                user_metrics.first_journal_at is not null
                 and user_metrics.last_journal_at is not null
-            then date_trunc('day', user_metrics.last_journal_at)::date - date_trunc('day', user_metrics.first_journal_at)::date + 1
+                then
+                    date_trunc('day', user_metrics.last_journal_at)::date
+                    - date_trunc('day', user_metrics.first_journal_at)::date
+                    + 1
             else null
         end as days_between_first_and_last_journal,
 
         round(
-            coalesce(user_metrics.total_journals, 0)::numeric /
-            nullif(coalesce(user_metrics.active_days, 0), 0),
+            coalesce(user_metrics.total_journals, 0)::numeric
+            / nullif(coalesce(user_metrics.active_days, 0), 0),
             2
         ) as journals_per_active_day
 

--- a/services/dbt/models/gold/analytics/user_topic_summary.sql
+++ b/services/dbt/models/gold/analytics/user_topic_summary.sql
@@ -9,7 +9,10 @@ with topics as (
 ),
 
 journal_entries as (
-    select journal_id, user_id from {{ ref('fct_journal_entries') }}
+    select
+        journal_id,
+        user_id
+    from {{ ref('fct_journal_entries') }}
 ),
 
 users as (
@@ -66,9 +69,16 @@ topic_ranks as (
         topic_name,
         count(*) as topic_count,
         avg(topic_confidence) as avg_confidence,
-        row_number() over (partition by user_id order by count(*) desc, avg(topic_confidence) desc) as rn
+        row_number() over (
+            partition by user_id
+            order by
+                count(*) desc,
+                avg(topic_confidence) desc
+        ) as rn
     from user_topics
-    group by user_id, topic_name
+    group by
+        user_id,
+        topic_name
 ),
 
 dominant_topic as (
@@ -90,7 +100,9 @@ subtopic_ranks as (
         row_number() over (partition by user_id order by count(*) desc) as rn
     from user_topics
     where subtopic_name is not null
-    group by user_id, subtopic_name
+    group by
+        user_id,
+        subtopic_name
 ),
 
 dominant_subtopic as (
@@ -107,11 +119,11 @@ final as (
         users.user_email,
 
         -- all-time metrics
-        coalesce(m.total_topic_assignments, 0) as total_topic_assignments,
-        coalesce(m.journals_with_topics, 0) as journals_with_topics,
-        coalesce(m.distinct_topics, 0) as distinct_topics,
-        coalesce(m.distinct_subtopics, 0) as distinct_subtopics,
-        round(m.avg_topic_confidence::numeric, 4) as avg_topic_confidence,
+        coalesce(user_topic_metrics.total_topic_assignments, 0) as total_topic_assignments,
+        coalesce(user_topic_metrics.journals_with_topics, 0) as journals_with_topics,
+        coalesce(user_topic_metrics.distinct_topics, 0) as distinct_topics,
+        coalesce(user_topic_metrics.distinct_subtopics, 0) as distinct_subtopics,
+        round(user_topic_metrics.avg_topic_confidence::numeric, 4) as avg_topic_confidence,
 
         -- dominant topic
         dominant_topic.dominant_topic,
@@ -120,17 +132,17 @@ final as (
         dominant_subtopic.dominant_subtopic,
 
         -- 30d metrics
-        coalesce(m30.total_topic_assignments_30d, 0) as total_topic_assignments_30d,
-        coalesce(m30.distinct_topics_30d, 0) as distinct_topics_30d,
-        round(m30.avg_topic_confidence_30d::numeric, 4) as avg_topic_confidence_30d,
+        coalesce(user_topic_metrics_30d.total_topic_assignments_30d, 0) as total_topic_assignments_30d,
+        coalesce(user_topic_metrics_30d.distinct_topics_30d, 0) as distinct_topics_30d,
+        round(user_topic_metrics_30d.avg_topic_confidence_30d::numeric, 4) as avg_topic_confidence_30d,
 
         -- timestamps
-        m.first_topic_at,
-        m.last_topic_at
+        user_topic_metrics.first_topic_at,
+        user_topic_metrics.last_topic_at
 
     from users
-    left join user_topic_metrics m on users.user_id = m.user_id
-    left join user_topic_metrics_30d m30 on users.user_id = m30.user_id
+    left join user_topic_metrics on users.user_id = user_topic_metrics.user_id
+    left join user_topic_metrics_30d on users.user_id = user_topic_metrics_30d.user_id
     left join dominant_topic on users.user_id = dominant_topic.user_id
     left join dominant_subtopic on users.user_id = dominant_subtopic.user_id
 )

--- a/services/dbt/models/silver/core/fct_game_bets.sql
+++ b/services/dbt/models/silver/core/fct_game_bets.sql
@@ -9,7 +9,7 @@ with bets as (
     select * from {{ ref('stg_user_game_bets') }}
 
     {% if is_incremental() %}
-    where created_at > coalesce((select max(bet_created_at) from {{ this }}), '1970-01-01'::timestamp)
+        where created_at > coalesce((select max(bet_created_at) from {{ this }}), '1970-01-01'::timestamp)
     {% endif %}
 ),
 

--- a/services/dbt/models/silver/core/fct_journal_entries.sql
+++ b/services/dbt/models/silver/core/fct_journal_entries.sql
@@ -9,7 +9,7 @@ with journals as (
     select * from {{ ref('stg_journals') }}
 
     {% if is_incremental() %}
-    where modified_at > coalesce((select max(journal_modified_at) from {{ this }}), '1970-01-01'::timestamp)
+        where modified_at > coalesce((select max(journal_modified_at) from {{ this }}), '1970-01-01'::timestamp)
     {% endif %}
 ),
 
@@ -17,7 +17,7 @@ journal_details as (
     select * from {{ ref('stg_journal_details') }}
 
     {% if is_incremental() %}
-    where modified_at > coalesce((select max(journal_modified_at) from {{ this }}), '1970-01-01'::timestamp)
+        where modified_at > coalesce((select max(journal_modified_at) from {{ this }}), '1970-01-01'::timestamp)
     {% endif %}
 ),
 
@@ -28,7 +28,7 @@ sentiments as (
     from {{ ref('stg_journal_sentiments') }}
 
     {% if is_incremental() %}
-    where journal_id in (select journal_id from journals)
+        where journal_id in (select journal_id from journals)
     {% endif %}
 ),
 
@@ -62,8 +62,9 @@ joined as (
     left join journal_details
         on journals.journal_id = journal_details.journal_id
     left join sentiments
-        on journals.journal_id = sentiments.journal_id
-        and sentiments.rn = 1
+        on
+            journals.journal_id = sentiments.journal_id
+            and sentiments.rn = 1
     left join topic_counts
         on journals.journal_id = topic_counts.journal_id
 )

--- a/services/dbt/models/silver/core/fct_journal_topics.sql
+++ b/services/dbt/models/silver/core/fct_journal_topics.sql
@@ -9,7 +9,7 @@ with topics as (
     select * from {{ ref('stg_journal_topics') }}
 
     {% if is_incremental() %}
-    where created_at > coalesce((select max(topic_created_at) from {{ this }}), '1970-01-01'::timestamp)
+        where created_at > coalesce((select max(topic_created_at) from {{ this }}), '1970-01-01'::timestamp)
     {% endif %}
 ),
 

--- a/services/dbt/models/silver/staging/stg_journal_details.sql
+++ b/services/dbt/models/silver/staging/stg_journal_details.sql
@@ -10,7 +10,7 @@ with source as (
     from {{ source('application_db', 'journal_details') }}
 
     {% if is_incremental() %}
-    where modified_at > coalesce((select max(modified_at) from {{ this }}), '1970-01-01'::timestamp)
+        where modified_at > coalesce((select max(modified_at) from {{ this }}), '1970-01-01'::timestamp)
     {% endif %}
 ),
 

--- a/services/dbt/models/silver/staging/stg_journal_sentiments.sql
+++ b/services/dbt/models/silver/staging/stg_journal_sentiments.sql
@@ -10,7 +10,7 @@ with source as (
     from {{ source('application_db', 'journal_sentiments') }}
 
     {% if is_incremental() %}
-    where created_at > coalesce((select max(created_at) from {{ this }}), '1970-01-01'::timestamp)
+        where created_at > coalesce((select max(created_at) from {{ this }}), '1970-01-01'::timestamp)
     {% endif %}
 ),
 

--- a/services/dbt/models/silver/staging/stg_journal_topics.sql
+++ b/services/dbt/models/silver/staging/stg_journal_topics.sql
@@ -10,7 +10,7 @@ with source as (
     from {{ source('application_db', 'journal_topics') }}
 
     {% if is_incremental() %}
-    where created_at > coalesce((select max(created_at) from {{ this }}), '1970-01-01'::timestamp)
+        where created_at > coalesce((select max(created_at) from {{ this }}), '1970-01-01'::timestamp)
     {% endif %}
 ),
 

--- a/services/dbt/models/silver/staging/stg_journals.sql
+++ b/services/dbt/models/silver/staging/stg_journals.sql
@@ -10,7 +10,7 @@ with source as (
     from {{ source('application_db', 'journals') }}
 
     {% if is_incremental() %}
-    where modified_at > coalesce((select max(modified_at) from {{ this }}), '1970-01-01'::timestamp)
+        where modified_at > coalesce((select max(modified_at) from {{ this }}), '1970-01-01'::timestamp)
     {% endif %}
 ),
 

--- a/services/dbt/models/silver/staging/stg_user_game_balances.sql
+++ b/services/dbt/models/silver/staging/stg_user_game_balances.sql
@@ -10,7 +10,7 @@ with source as (
     from {{ source('application_db', 'user_game_balances') }}
 
     {% if is_incremental() %}
-    where modified_at > coalesce((select max(modified_at) from {{ this }}), '1970-01-01'::timestamp)
+        where modified_at > coalesce((select max(modified_at) from {{ this }}), '1970-01-01'::timestamp)
     {% endif %}
 ),
 

--- a/services/dbt/models/silver/staging/stg_user_game_bets.sql
+++ b/services/dbt/models/silver/staging/stg_user_game_bets.sql
@@ -10,7 +10,7 @@ with source as (
     from {{ source('application_db', 'user_game_bets') }}
 
     {% if is_incremental() %}
-    where created_at > coalesce((select max(created_at) from {{ this }}), '1970-01-01'::timestamp)
+        where created_at > coalesce((select max(created_at) from {{ this }}), '1970-01-01'::timestamp)
     {% endif %}
 ),
 

--- a/services/dbt/models/silver/staging/stg_users.sql
+++ b/services/dbt/models/silver/staging/stg_users.sql
@@ -10,7 +10,7 @@ with source as (
     from {{ source('application_db', 'users') }}
 
     {% if is_incremental() %}
-    where modified_at > coalesce((select max(modified_at) from {{ this }}), '1970-01-01'::timestamp)
+        where modified_at > coalesce((select max(modified_at) from {{ this }}), '1970-01-01'::timestamp)
     {% endif %}
 ),
 

--- a/services/dbt/pyproject.toml
+++ b/services/dbt/pyproject.toml
@@ -8,3 +8,54 @@ dependencies = [
     "dbt-core>=1.10.13",
     "dbt-postgres>=1.9.1",
 ]
+
+[dependency-groups]
+dev = [
+    "sqlfluff>=4.1.0",
+    "sqlfluff-templater-dbt>=4.1.0",
+]
+
+[tool.sqlfluff.core]
+dialect = "postgres"
+templater = "dbt"
+rules = "aliasing.forbid,capitalisation,jinja,layout"
+sql_file_exts = ".sql"
+max_line_length = 120
+
+[tool.sqlfluff.indentation]
+indented_joins = false
+
+[tool.sqlfluff.templater.dbt]
+project_dir = "."
+profiles_dir = "./profiles"
+profile = "local"
+
+[tool.sqlfluff.layout.type.groupby_clause]
+line_position = "alone:strict"
+keyword_line_position = "leading"
+
+[tool.sqlfluff.layout.type.join_clause]
+line_position = "alone:strict"
+
+[tool.sqlfluff.layout.type.orderby_clause]
+line_position = "alone:strict"
+keyword_line_position = "leading"
+keyword_line_position_exclusions = "window_specification,aggregate_order_by,withingroup_clause,pipe_operator_clause"
+
+[tool.sqlfluff.rules.capitalisation.keywords]
+capitalisation_policy = "lower"
+
+[tool.sqlfluff.rules.capitalisation.identifiers]
+extended_capitalisation_policy = "lower"
+
+[tool.sqlfluff.rules.capitalisation.functions]
+extended_capitalisation_policy = "lower"
+
+[tool.sqlfluff.rules.capitalisation.literals]
+capitalisation_policy = "lower"
+
+[tool.sqlfluff.rules.capitalisation.types]
+extended_capitalisation_policy = "lower"
+
+[tool.sqlfluff.rules.aliasing.forbid]
+force_enable = true

--- a/services/dbt/uv.lock
+++ b/services/dbt/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.13"
 
 [[package]]
@@ -29,10 +29,22 @@ dependencies = [
     { name = "dbt-postgres" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "sqlfluff" },
+    { name = "sqlfluff-templater-dbt" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "dbt-core", specifier = ">=1.10.13" },
     { name = "dbt-postgres", specifier = ">=1.9.1" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "sqlfluff", specifier = ">=4.1.0" },
+    { name = "sqlfluff-templater-dbt", specifier = ">=4.1.0" },
 ]
 
 [[package]]
@@ -69,6 +81,31 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/4c/5b/b6ce21586237c77ce67d01dc5507039d444b630dd76611bbca2d8e5dcd91/certifi-2025.10.5.tar.gz", hash = "sha256:47c09d31ccf2acf0be3f701ea53595ee7e0b8fa08801c6624be771df09ae7b43", size = 164519, upload-time = "2025-10-05T04:12:15.808Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e4/37/af0d2ef3967ac0d6113837b44a4f0bfe1328c2b9763bd5b1744520e5cfed/certifi-2025.10.5-py3-none-any.whl", hash = "sha256:0f212c2744a9bb6de0c56639a6f68afe01ecd92d91f14ae897c4fe7bbeeef0de", size = 163286, upload-time = "2025-10-05T04:12:14.03Z" },
+]
+
+[[package]]
+name = "chardet"
+version = "7.4.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/b6/9df434a8eeba2e6628c465a1dfa31034228ef79b26f76f46278f4ef7e49d/chardet-7.4.3.tar.gz", hash = "sha256:cc1d4eb92a4ec1c2df3b490836ffa46922e599d34ce0bb75cf41fd2bf6303d56", size = 784800, upload-time = "2026-04-13T21:33:39.803Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/43/79ac9b4db5bc87020c9dbc419125371d80882d1d197e9c4765ba8682b605/chardet-7.4.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:a9e4486df251b8962e86ea9f139ca235aa6e0542a00f7844c9a04160afb99aa9", size = 873769, upload-time = "2026-04-13T21:33:14.002Z" },
+    { url = "https://files.pythonhosted.org/packages/55/5f/25bdec773905bff0ff6cf35ca73b17bd05593b4f87bd8c5fa43705f7167d/chardet-7.4.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:4fbff1907925b0c5a1064cffb5e040cd5e338585c9c552625f30de6bc2f3107a", size = 853991, upload-time = "2026-04-13T21:33:15.564Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/07/a29380ee0b215d23d77733b5ad60c5c0c7969650e080c667acdf9462040d/chardet-7.4.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:365135eaf37ba65a828f8e668eb0a8c38c479dcbec724dc25f4dfd781049c357", size = 874024, upload-time = "2026-04-13T21:33:16.915Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/b1/3338e121cbd4c8a126b8ccb1061170c2ce51a53f678c502793ea49c6fd6d/chardet-7.4.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bfc134b70c846c21ead8e43ada3ae1a805fff732f6922f8abcf2ff27b8f6493d", size = 887410, upload-time = "2026-04-13T21:33:18.368Z" },
+    { url = "https://files.pythonhosted.org/packages/63/1c/44a9a9e0c59c185a5d307ceaeee8768afa1558f0a24f7a4b5fa11b67586b/chardet-7.4.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9acd9988a93e09390f3cd231201ea7166c415eb8da1b735928990ffc05cb9fbb", size = 879269, upload-time = "2026-04-13T21:33:20.377Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/b3/5d0e77ea774bd3224321c248880ea0c0379000ac5c2bb6d77609549de247/chardet-7.4.3-cp313-cp313-win_amd64.whl", hash = "sha256:e1b98790c284ff813f18f7cf7de5f05ea2435a080030c7f1a8318f3a4f80b131", size = 944155, upload-time = "2026-04-13T21:33:21.694Z" },
+    { url = "https://files.pythonhosted.org/packages/70/a8/bf0811d859e13801279a2ae64f37a408027b282f2047bc0001c75dd356ad/chardet-7.4.3-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:d892d3dcd652fdef53e3d6327d39b17c0df40a899dfc919abaeb64c974497531", size = 872887, upload-time = "2026-04-13T21:33:23.328Z" },
+    { url = "https://files.pythonhosted.org/packages/51/ac/b9d68ebddfe1b02c77af5bf81120e12b036b4432dc6af7a303d90e2bc38b/chardet-7.4.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:acc46d1b8b7d5783216afe15db56d1c179b9a40e5a1558bc13164c4fd20674c4", size = 853964, upload-time = "2026-04-13T21:33:24.724Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/81/17fa103ea9caf5d325a5e4051ab2ba65996fd66baa60b81ee41af1f54e10/chardet-7.4.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ac3bf11c645734a1701a3804e43eabd98851838192267d08c353a834ab79fea", size = 876006, upload-time = "2026-04-13T21:33:26.098Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/20/193faab46a68ea550587331a698c3dca8099f8901d10937c4443135c7ed9/chardet-7.4.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6e3bd9f936e04bae89c254262af08d9e5b98f805175ba1e29d454e6cba3107b7", size = 887680, upload-time = "2026-04-13T21:33:27.49Z" },
+    { url = "https://files.pythonhosted.org/packages/40/c6/94a3c673327392652ee8bdea9a45bc8a5f5365197a7387d68f0eed007115/chardet-7.4.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:27cc23da03630cdecc9aa81a895aa86629c211f995cd57651f0fbc280717bf93", size = 879865, upload-time = "2026-04-13T21:33:29.052Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/2c/cad8b5e3623a987f3c930b68e2bdd06cfc388cd91cd42ed05f1227701b73/chardet-7.4.3-cp314-cp314-win_amd64.whl", hash = "sha256:b95c934b9ad59e2ba8abb9be49df70d3ad1b0d95d864b9fdb7588d4fa8bd921c", size = 939594, upload-time = "2026-04-13T21:33:31.391Z" },
+    { url = "https://files.pythonhosted.org/packages/33/e0/d06e42fd6f02a58e5e227e5106587751cb38adcff0aaf949add744b78b6e/chardet-7.4.3-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:c77867f0c1cb8bd819502249fcdc500364aedb07881e11b743726fa2148e7b6e", size = 889714, upload-time = "2026-04-13T21:33:32.772Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/ed/40d091954d48abea037baae6be8fb79905e5f78d34d12ea955132c7d8011/chardet-7.4.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:cf1efeaf65a6ef2f5b9cc3a1df6f08ba2831b369ccaa4c7018eaf90aa757bb11", size = 872319, upload-time = "2026-04-13T21:33:34.427Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/77/82a46821dbfbdfe062710d2bf2ede13426304e3567a23c57d919c0c31630/chardet-7.4.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9f3504c139a2ad544077dd2d9e412cd08b01786843d76997cd43bb6de311723c", size = 892021, upload-time = "2026-04-13T21:33:35.766Z" },
+    { url = "https://files.pythonhosted.org/packages/49/57/42d30c562bda5b4a839766c1aad8d5856b798ad2a1c3247b72a679afec94/chardet-7.4.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:457f619882ba66327d4d8d14c6c342269bdb1e4e1c38e8117df941d14d351b04", size = 902509, upload-time = "2026-04-13T21:33:37.096Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/6c/0a40afdb50a0fe041ab95553b835a8160b6cf0e81edf2ae2fe9f5224cbf9/chardet-7.4.3-py3-none-any.whl", hash = "sha256:1173b74051570cf08099d7429d92e4882d375ad4217f92a6e5240ccfb26f231e", size = 626562, upload-time = "2026-04-13T21:33:38.559Z" },
 ]
 
 [[package]]
@@ -291,6 +328,21 @@ wheels = [
 ]
 
 [[package]]
+name = "diff-cover"
+version = "10.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "chardet" },
+    { name = "jinja2" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/99/b4/eee71d1e338bc1f9bd3539b46b70e303dac061324b759c9a80fa3c96d90d/diff_cover-10.2.0.tar.gz", hash = "sha256:61bf83025f10510c76ef6a5820680cf61b9b974e8f81de70c57ac926fa63872a", size = 102473, upload-time = "2026-01-09T01:59:07.605Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/2c/61eeb887055a37150db824b6bf830e821a736580769ac2fea4eadb0d613f/diff_cover-10.2.0-py3-none-any.whl", hash = "sha256:59c328595e0b8948617cc5269af9e484c86462e2844bfcafa3fb37f8fca0af87", size = 56748, upload-time = "2026-01-09T01:59:06.028Z" },
+]
+
+[[package]]
 name = "idna"
 version = "3.10"
 source = { registry = "https://pypi.org/simple" }
@@ -309,6 +361,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/76/66/650a33bd90f786193e4de4b3ad86ea60b53c89b669a5c7be931fac31cdb0/importlib_metadata-8.7.0.tar.gz", hash = "sha256:d13b81ad223b890aa16c5471f2ac3056cf76c5f10f82d6f9292f0b415f389000", size = 56641, upload-time = "2025-04-27T15:29:01.736Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/20/b0/36bd937216ec521246249be3bf9855081de4c5e06a0c9b4219dbeda50373/importlib_metadata-8.7.0-py3-none-any.whl", hash = "sha256:e5dd1551894c77868a30651cef00984d50e1002d06942a7101d34870c5f02afd", size = 27656, upload-time = "2025-04-27T15:29:00.214Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
 ]
 
 [[package]]
@@ -333,6 +394,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "jinja2-simple-tags"
+version = "0.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jinja2" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d8/b7/a2c8a0c60e6f2cb0dbc5020b43df7b0dc9a8fae0767c2f72665a1c7b76c9/jinja2-simple-tags-0.6.1.tar.gz", hash = "sha256:54abf83883dcd13f8fd2ea2c42feeea8418df3640907bd5251dec5e25a6af0e3", size = 9849, upload-time = "2024-03-06T11:52:36.28Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/05/8fd074379bdfeb5ce1bccf4a8e23e004e1f238938724f743267759da94e3/jinja2_simple_tags-0.6.1-py2.py3-none-any.whl", hash = "sha256:7b7cfa92f6813a1e0f0b61b9efcab60e6793674753e1f784ff270542e80ae20f", size = 5817, upload-time = "2024-03-06T11:52:34.575Z" },
 ]
 
 [[package]]
@@ -513,6 +586,24 @@ wheels = [
 ]
 
 [[package]]
+name = "platformdirs"
+version = "4.9.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9f/4a/0883b8e3802965322523f0b200ecf33d31f10991d0401162f4b23c698b42/platformdirs-4.9.6.tar.gz", hash = "sha256:3bfa75b0ad0db84096ae777218481852c0ebc6c727b3168c1b9e0118e458cf0a", size = 29400, upload-time = "2026-04-09T00:04:10.812Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/75/a6/a0a304dc33b49145b21f4808d763822111e67d1c3a32b524a1baf947b6e1/platformdirs-4.9.6-py3-none-any.whl", hash = "sha256:e61adb1d5e5cb3441b4b7710bea7e4c12250ca49439228cc1021c00dcfac0917", size = 21348, upload-time = "2026-04-09T00:04:09.463Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
 name = "protobuf"
 version = "6.32.1"
 source = { registry = "https://pypi.org/simple" }
@@ -586,6 +677,31 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a4/7d/e09391c2eebeab681df2b74bfe6c43422fffede8dc74187b2b0bf6fd7571/pydantic_core-2.33.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:61c18fba8e5e9db3ab908620af374db0ac1baa69f0f32df4f61ae23f15e586ac", size = 1806162, upload-time = "2025-04-23T18:32:20.188Z" },
     { url = "https://files.pythonhosted.org/packages/f1/3d/847b6b1fed9f8ed3bb95a9ad04fbd0b212e832d4f0f50ff4d9ee5a9f15cf/pydantic_core-2.33.2-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:95237e53bb015f67b63c91af7518a62a8660376a6a0db19b89acc77a4d6199f5", size = 1981560, upload-time = "2025-04-23T18:32:22.354Z" },
     { url = "https://files.pythonhosted.org/packages/6f/9a/e73262f6c6656262b5fdd723ad90f518f579b7bc8622e43a942eec53c938/pydantic_core-2.33.2-cp313-cp313t-win_amd64.whl", hash = "sha256:c2fc0a768ef76c15ab9238afa6da7f69895bb5d1ee83aeea2e3509af4472d0b9", size = 1935777, upload-time = "2025-04-23T18:32:25.088Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
 ]
 
 [[package]]
@@ -677,6 +793,78 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/2f/db/98b5c277be99dd18bfd91dd04e1b759cad18d1a338188c936e92f921c7e2/referencing-0.36.2.tar.gz", hash = "sha256:df2e89862cd09deabbdba16944cc3f10feb6b3e6f18e902f7cc25609a34775aa", size = 74744, upload-time = "2025-01-25T08:48:16.138Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c1/b1/3baf80dc6d2b7bc27a95a67752d0208e410351e3feb4eb78de5f77454d8d/referencing-0.36.2-py3-none-any.whl", hash = "sha256:e8699adbbf8b5c7de96d8ffa0eb5c158b3beafce084968e2ea8bb08c6794dcd0", size = 26775, upload-time = "2025-01-25T08:48:14.241Z" },
+]
+
+[[package]]
+name = "regex"
+version = "2026.4.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cb/0e/3a246dbf05666918bd3664d9d787f84a9108f6f43cc953a077e4a7dfdb7e/regex-2026.4.4.tar.gz", hash = "sha256:e08270659717f6973523ce3afbafa53515c4dc5dcad637dc215b6fd50f689423", size = 416000, upload-time = "2026-04-03T20:56:28.155Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/83/c4373bc5f31f2cf4b66f9b7c31005bd87fe66f0dce17701f7db4ee79ee29/regex-2026.4.4-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:62f5519042c101762509b1d717b45a69c0139d60414b3c604b81328c01bd1943", size = 490273, upload-time = "2026-04-03T20:54:11.202Z" },
+    { url = "https://files.pythonhosted.org/packages/46/f8/fe62afbcc3cf4ad4ac9adeaafd98aa747869ae12d3e8e2ac293d0593c435/regex-2026.4.4-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:3790ba9fb5dd76715a7afe34dbe603ba03f8820764b1dc929dd08106214ed031", size = 291954, upload-time = "2026-04-03T20:54:13.412Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/92/4712b9fe6a33d232eeb1c189484b80c6c4b8422b90e766e1195d6e758207/regex-2026.4.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8fae3c6e795d7678963f2170152b0d892cf6aee9ee8afc8c45e6be38d5107fe7", size = 289487, upload-time = "2026-04-03T20:54:15.824Z" },
+    { url = "https://files.pythonhosted.org/packages/88/2c/f83b93f85e01168f1070f045a42d4c937b69fdb8dd7ae82d307253f7e36e/regex-2026.4.4-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:298c3ec2d53225b3bf91142eb9691025bab610e0c0c51592dde149db679b3d17", size = 796646, upload-time = "2026-04-03T20:54:18.229Z" },
+    { url = "https://files.pythonhosted.org/packages/df/55/61a2e17bf0c4dc57e11caf8dd11771280d8aaa361785f9e3bc40d653f4a7/regex-2026.4.4-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e9638791082eaf5b3ac112c587518ee78e083a11c4b28012d8fe2a0f536dfb17", size = 865904, upload-time = "2026-04-03T20:54:20.019Z" },
+    { url = "https://files.pythonhosted.org/packages/45/32/1ac8ed1b5a346b5993a3d256abe0a0f03b0b73c8cc88d928537368ac65b6/regex-2026.4.4-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ae3e764bd4c5ff55035dc82a8d49acceb42a5298edf6eb2fc4d328ee5dd7afae", size = 912304, upload-time = "2026-04-03T20:54:22.403Z" },
+    { url = "https://files.pythonhosted.org/packages/26/47/2ee5c613ab546f0eddebf9905d23e07beb933416b1246c2d8791d01979b4/regex-2026.4.4-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ffa81f81b80047ba89a3c69ae6a0f78d06f4a42ce5126b0eb2a0a10ad44e0b2e", size = 801126, upload-time = "2026-04-03T20:54:24.308Z" },
+    { url = "https://files.pythonhosted.org/packages/75/cd/41dacd129ca9fd20bd7d02f83e0fad83e034ac8a084ec369c90f55ef37e2/regex-2026.4.4-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f56ebf9d70305307a707911b88469213630aba821e77de7d603f9d2f0730687d", size = 776772, upload-time = "2026-04-03T20:54:26.319Z" },
+    { url = "https://files.pythonhosted.org/packages/89/6d/5af0b588174cb5f46041fa7dd64d3fd5cd2fe51f18766703d1edc387f324/regex-2026.4.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:773d1dfd652bbffb09336abf890bfd64785c7463716bf766d0eb3bc19c8b7f27", size = 785228, upload-time = "2026-04-03T20:54:28.387Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/3b/f5a72b7045bd59575fc33bf1345f156fcfd5a8484aea6ad84b12c5a82114/regex-2026.4.4-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:d51d20befd5275d092cdffba57ded05f3c436317ee56466c8928ac32d960edaf", size = 860032, upload-time = "2026-04-03T20:54:30.641Z" },
+    { url = "https://files.pythonhosted.org/packages/39/a4/72a317003d6fcd7a573584a85f59f525dfe8f67e355ca74eb6b53d66a5e2/regex-2026.4.4-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:0a51cdb3c1e9161154f976cb2bef9894bc063ac82f31b733087ffb8e880137d0", size = 765714, upload-time = "2026-04-03T20:54:32.789Z" },
+    { url = "https://files.pythonhosted.org/packages/25/1e/5672e16f34dbbcb2560cc7e6a2fbb26dfa8b270711e730101da4423d3973/regex-2026.4.4-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:ae5266a82596114e41fb5302140e9630204c1b5f325c770bec654b95dd54b0aa", size = 852078, upload-time = "2026-04-03T20:54:34.546Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/0d/c813f0af7c6cc7ed7b9558bac2e5120b60ad0fa48f813e4d4bd55446f214/regex-2026.4.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:c882cd92ec68585e9c1cf36c447ec846c0d94edd706fe59e0c198e65822fd23b", size = 789181, upload-time = "2026-04-03T20:54:36.642Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/6d/a344608d1adbd2a95090ddd906cec09a11be0e6517e878d02a5123e0917f/regex-2026.4.4-cp313-cp313-win32.whl", hash = "sha256:05568c4fbf3cb4fa9e28e3af198c40d3237cf6041608a9022285fe567ec3ad62", size = 266690, upload-time = "2026-04-03T20:54:38.343Z" },
+    { url = "https://files.pythonhosted.org/packages/31/07/54049f89b46235ca6f45cd6c88668a7050e77d4a15555e47dd40fde75263/regex-2026.4.4-cp313-cp313-win_amd64.whl", hash = "sha256:3384df51ed52db0bea967e21458ab0a414f67cdddfd94401688274e55147bb81", size = 277733, upload-time = "2026-04-03T20:54:40.11Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/21/61366a8e20f4d43fb597708cac7f0e2baadb491ecc9549b4980b2be27d16/regex-2026.4.4-cp313-cp313-win_arm64.whl", hash = "sha256:acd38177bd2c8e69a411d6521760806042e244d0ef94e2dd03ecdaa8a3c99427", size = 270565, upload-time = "2026-04-03T20:54:41.883Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/1e/3a2b9672433bef02f5d39aa1143ca2c08f311c1d041c464a42be9ae648dc/regex-2026.4.4-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:f94a11a9d05afcfcfa640e096319720a19cc0c9f7768e1a61fceee6a3afc6c7c", size = 494126, upload-time = "2026-04-03T20:54:43.602Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/4b/c132a4f4fe18ad3340d89fcb56235132b69559136036b845be3c073142ed/regex-2026.4.4-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:36bcb9d6d1307ab629edc553775baada2aefa5c50ccc0215fbfd2afcfff43141", size = 293882, upload-time = "2026-04-03T20:54:45.41Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/5f/eaa38092ce7a023656280f2341dbbd4ad5f05d780a70abba7bb4f4bea54c/regex-2026.4.4-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:261c015b3e2ed0919157046d768774ecde57f03d8fa4ba78d29793447f70e717", size = 292334, upload-time = "2026-04-03T20:54:47.051Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/f6/dd38146af1392dac33db7074ab331cec23cced3759167735c42c5460a243/regex-2026.4.4-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c228cf65b4a54583763645dcd73819b3b381ca8b4bb1b349dee1c135f4112c07", size = 811691, upload-time = "2026-04-03T20:54:49.074Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/f0/dc54c2e69f5eeec50601054998ec3690d5344277e782bd717e49867c1d29/regex-2026.4.4-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:dd2630faeb6876fb0c287f664d93ddce4d50cd46c6e88e60378c05c9047e08ca", size = 871227, upload-time = "2026-04-03T20:54:51.035Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/af/cb16bd5dc61621e27df919a4449bbb7e5a1034c34d307e0a706e9cc0f3e3/regex-2026.4.4-cp313-cp313t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:6a50ab11b7779b849472337191f3a043e27e17f71555f98d0092fa6d73364520", size = 917435, upload-time = "2026-04-03T20:54:52.994Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/71/8b260897f22996b666edd9402861668f45a2ca259f665ac029e6104a2d7d/regex-2026.4.4-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0734f63afe785138549fbe822a8cfeaccd1bae814c5057cc0ed5b9f2de4fc883", size = 816358, upload-time = "2026-04-03T20:54:54.884Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/60/775f7f72a510ef238254906c2f3d737fc80b16ca85f07d20e318d2eea894/regex-2026.4.4-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c4ee50606cb1967db7e523224e05f32089101945f859928e65657a2cbb3d278b", size = 785549, upload-time = "2026-04-03T20:54:57.01Z" },
+    { url = "https://files.pythonhosted.org/packages/58/42/34d289b3627c03cf381e44da534a0021664188fa49ba41513da0b4ec6776/regex-2026.4.4-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:6c1818f37be3ca02dcb76d63f2c7aaba4b0dc171b579796c6fbe00148dfec6b1", size = 801364, upload-time = "2026-04-03T20:54:58.981Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/20/f6ecf319b382a8f1ab529e898b222c3f30600fcede7834733c26279e7465/regex-2026.4.4-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:f5bfc2741d150d0be3e4a0401a5c22b06e60acb9aa4daa46d9e79a6dcd0f135b", size = 866221, upload-time = "2026-04-03T20:55:00.88Z" },
+    { url = "https://files.pythonhosted.org/packages/92/6a/9f16d3609d549bd96d7a0b2aee1625d7512ba6a03efc01652149ef88e74d/regex-2026.4.4-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:504ffa8a03609a087cad81277a629b6ce884b51a24bd388a7980ad61748618ff", size = 772530, upload-time = "2026-04-03T20:55:03.213Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/f6/aa9768bc96a4c361ac96419fbaf2dcdc33970bb813df3ba9b09d5d7b6d96/regex-2026.4.4-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:70aadc6ff12e4b444586e57fc30771f86253f9f0045b29016b9605b4be5f7dfb", size = 856989, upload-time = "2026-04-03T20:55:05.087Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/b4/c671db3556be2473ae3e4bb7a297c518d281452871501221251ea4ecba57/regex-2026.4.4-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:f4f83781191007b6ef43b03debc35435f10cad9b96e16d147efe84a1d48bdde4", size = 803241, upload-time = "2026-04-03T20:55:07.162Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/5c/83e3b1d89fa4f6e5a1bc97b4abd4a9a97b3c1ac7854164f694f5f0ba98a0/regex-2026.4.4-cp313-cp313t-win32.whl", hash = "sha256:e014a797de43d1847df957c0a2a8e861d1c17547ee08467d1db2c370b7568baa", size = 269921, upload-time = "2026-04-03T20:55:09.62Z" },
+    { url = "https://files.pythonhosted.org/packages/28/07/077c387121f42cdb4d92b1301133c0d93b5709d096d1669ab847dda9fe2e/regex-2026.4.4-cp313-cp313t-win_amd64.whl", hash = "sha256:b15b88b0d52b179712632832c1d6e58e5774f93717849a41096880442da41ab0", size = 281240, upload-time = "2026-04-03T20:55:11.521Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/22/ead4a4abc7c59a4d882662aa292ca02c8b617f30b6e163bc1728879e9353/regex-2026.4.4-cp313-cp313t-win_arm64.whl", hash = "sha256:586b89cdadf7d67bf86ae3342a4dcd2b8d70a832d90c18a0ae955105caf34dbe", size = 272440, upload-time = "2026-04-03T20:55:13.365Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/f5/ed97c2dc47b5fbd4b73c0d7d75f9ebc8eca139f2bbef476bba35f28c0a77/regex-2026.4.4-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:2da82d643fa698e5e5210e54af90181603d5853cf469f5eedf9bfc8f59b4b8c7", size = 490343, upload-time = "2026-04-03T20:55:15.241Z" },
+    { url = "https://files.pythonhosted.org/packages/80/e9/de4828a7385ec166d673a5790ad06ac48cdaa98bc0960108dd4b9cc1aef7/regex-2026.4.4-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:54a1189ad9d9357760557c91103d5e421f0a2dabe68a5cdf9103d0dcf4e00752", size = 291909, upload-time = "2026-04-03T20:55:17.558Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/d6/5cfbfc97f3201a4d24b596a77957e092030dcc4205894bc035cedcfce62f/regex-2026.4.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:76d67d5afb1fe402d10a6403bae668d000441e2ab115191a804287d53b772951", size = 289692, upload-time = "2026-04-03T20:55:20.561Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/ac/f2212d9fd56fe897e36d0110ba30ba2d247bd6410c5bd98499c7e5a1e1f2/regex-2026.4.4-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e7cd3e4ee8d80447a83bbc9ab0c8459781fa77087f856c3e740d7763be0df27f", size = 796979, upload-time = "2026-04-03T20:55:22.56Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/e3/a016c12675fbac988a60c7e1c16e67823ff0bc016beb27bd7a001dbdabc6/regex-2026.4.4-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2e19e18c568d2866d8b6a6dfad823db86193503f90823a8f66689315ba28fbe8", size = 866744, upload-time = "2026-04-03T20:55:24.646Z" },
+    { url = "https://files.pythonhosted.org/packages/af/a4/0b90ca4cf17adc3cb43de80ec71018c37c88ad64987e8d0d481a95ca60b5/regex-2026.4.4-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:7698a6f38730fd1385d390d1ed07bb13dce39aa616aca6a6d89bea178464b9a4", size = 911613, upload-time = "2026-04-03T20:55:27.033Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/3b/2b3dac0b82d41ab43aa87c6ecde63d71189d03fe8854b8ca455a315edac3/regex-2026.4.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:173a66f3651cdb761018078e2d9487f4cf971232c990035ec0eb1cdc6bf929a9", size = 800551, upload-time = "2026-04-03T20:55:29.532Z" },
+    { url = "https://files.pythonhosted.org/packages/25/fe/5365eb7aa0e753c4b5957815c321519ecab033c279c60e1b1ae2367fa810/regex-2026.4.4-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:fa7922bbb2cc84fa062d37723f199d4c0cd200245ce269c05db82d904db66b83", size = 776911, upload-time = "2026-04-03T20:55:31.526Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/b3/7fb0072156bba065e3b778a7bc7b0a6328212be5dd6a86fd207e0c4f2dab/regex-2026.4.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:59f67cd0a0acaf0e564c20bbd7f767286f23e91e2572c5703bf3e56ea7557edb", size = 785751, upload-time = "2026-04-03T20:55:33.797Z" },
+    { url = "https://files.pythonhosted.org/packages/02/1a/9f83677eb699273e56e858f7bd95acdbee376d42f59e8bfca2fd80d79df3/regex-2026.4.4-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:475e50f3f73f73614f7cba5524d6de49dee269df00272a1b85e3d19f6d498465", size = 860484, upload-time = "2026-04-03T20:55:35.745Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/7a/93937507b61cfcff8b4c5857f1b452852b09f741daa9acae15c971d8554e/regex-2026.4.4-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:a1c0c7d67b64d85ac2e1879923bad2f08a08f3004055f2f406ef73c850114bd4", size = 765939, upload-time = "2026-04-03T20:55:37.972Z" },
+    { url = "https://files.pythonhosted.org/packages/86/ea/81a7f968a351c6552b1670ead861e2a385be730ee28402233020c67f9e0f/regex-2026.4.4-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:1371c2ccbb744d66ee63631cc9ca12aa233d5749972626b68fe1a649dd98e566", size = 851417, upload-time = "2026-04-03T20:55:39.92Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/7e/323c18ce4b5b8f44517a36342961a0306e931e499febbd876bb149d900f0/regex-2026.4.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:59968142787042db793348a3f5b918cf24ced1f23247328530e063f89c128a95", size = 789056, upload-time = "2026-04-03T20:55:42.303Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/af/e7510f9b11b1913b0cd44eddb784b2d650b2af6515bfce4cffcc5bfd1d38/regex-2026.4.4-cp314-cp314-win32.whl", hash = "sha256:59efe72d37fd5a91e373e5146f187f921f365f4abc1249a5ab446a60f30dd5f8", size = 272130, upload-time = "2026-04-03T20:55:44.995Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/51/57dae534c915e2d3a21490e88836fa2ae79dde3b66255ecc0c0a155d2c10/regex-2026.4.4-cp314-cp314-win_amd64.whl", hash = "sha256:e0aab3ff447845049d676827d2ff714aab4f73f340e155b7de7458cf53baa5a4", size = 280992, upload-time = "2026-04-03T20:55:47.316Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/5e/abaf9f4c3792e34edb1434f06717fae2b07888d85cb5cec29f9204931bf8/regex-2026.4.4-cp314-cp314-win_arm64.whl", hash = "sha256:a7a5bb6aa0cf62208bb4fa079b0c756734f8ad0e333b425732e8609bd51ee22f", size = 273563, upload-time = "2026-04-03T20:55:49.273Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/06/35da85f9f217b9538b99cbb170738993bcc3b23784322decb77619f11502/regex-2026.4.4-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:97850d0638391bdc7d35dc1c1039974dcb921eaafa8cc935ae4d7f272b1d60b3", size = 494191, upload-time = "2026-04-03T20:55:51.258Z" },
+    { url = "https://files.pythonhosted.org/packages/54/5b/1bc35f479eef8285c4baf88d8c002023efdeebb7b44a8735b36195486ae7/regex-2026.4.4-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:ee7337f88f2a580679f7bbfe69dc86c043954f9f9c541012f49abc554a962f2e", size = 293877, upload-time = "2026-04-03T20:55:53.214Z" },
+    { url = "https://files.pythonhosted.org/packages/39/5b/f53b9ad17480b3ddd14c90da04bfb55ac6894b129e5dea87bcaf7d00e336/regex-2026.4.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7429f4e6192c11d659900c0648ba8776243bf396ab95558b8c51a345afeddde6", size = 292410, upload-time = "2026-04-03T20:55:55.736Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/56/52377f59f60a7c51aa4161eecf0b6032c20b461805aca051250da435ffc9/regex-2026.4.4-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dc4f10fbd5dd13dcf4265b4cc07d69ca70280742870c97ae10093e3d66000359", size = 811831, upload-time = "2026-04-03T20:55:57.802Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/63/8026310bf066f702a9c361f83a8c9658f3fe4edb349f9c1e5d5273b7c40c/regex-2026.4.4-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a152560af4f9742b96f3827090f866eeec5becd4765c8e0d3473d9d280e76a5a", size = 871199, upload-time = "2026-04-03T20:56:00.333Z" },
+    { url = "https://files.pythonhosted.org/packages/20/9f/a514bbb00a466dbb506d43f187a04047f7be1505f10a9a15615ead5080ee/regex-2026.4.4-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:54170b3e95339f415d54651f97df3bff7434a663912f9358237941bbf9143f55", size = 917649, upload-time = "2026-04-03T20:56:02.445Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/6b/8399f68dd41a2030218839b9b18360d79b86d22b9fab5ef477c7f23ca67c/regex-2026.4.4-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:07f190d65f5a72dcb9cf7106bfc3d21e7a49dd2879eda2207b683f32165e4d99", size = 816388, upload-time = "2026-04-03T20:56:04.595Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/9c/103963f47c24339a483b05edd568594c2be486188f688c0170fd504b2948/regex-2026.4.4-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9a2741ce5a29d3c84b0b94261ba630ab459a1b847a0d6beca7d62d188175c790", size = 785746, upload-time = "2026-04-03T20:56:07.13Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/ee/7f6054c0dec0cee3463c304405e4ff42e27cff05bf36fcb34be549ab17bd/regex-2026.4.4-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:b26c30df3a28fd9793113dac7385a4deb7294a06c0f760dd2b008bd49a9139bc", size = 801483, upload-time = "2026-04-03T20:56:09.365Z" },
+    { url = "https://files.pythonhosted.org/packages/30/c2/51d3d941cf6070dc00c3338ecf138615fc3cce0421c3df6abe97a08af61a/regex-2026.4.4-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:421439d1bee44b19f4583ccf42670ca464ffb90e9fdc38d37f39d1ddd1e44f1f", size = 866331, upload-time = "2026-04-03T20:56:12.039Z" },
+    { url = "https://files.pythonhosted.org/packages/16/e8/76d50dcc122ac33927d939f350eebcfe3dbcbda96913e03433fc36de5e63/regex-2026.4.4-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:b40379b53ecbc747fd9bdf4a0ea14eb8188ca1bd0f54f78893a39024b28f4863", size = 772673, upload-time = "2026-04-03T20:56:14.558Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/6e/5f6bf75e20ea6873d05ba4ec78378c375cbe08cdec571c83fbb01606e563/regex-2026.4.4-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:08c55c13d2eef54f73eeadc33146fb0baaa49e7335eb1aff6ae1324bf0ddbe4a", size = 857146, upload-time = "2026-04-03T20:56:16.663Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/33/3c76d9962949e487ebba353a18e89399f292287204ac8f2f4cfc3a51c233/regex-2026.4.4-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9776b85f510062f5a75ef112afe5f494ef1635607bf1cc220c1391e9ac2f5e81", size = 803463, upload-time = "2026-04-03T20:56:18.923Z" },
+    { url = "https://files.pythonhosted.org/packages/19/eb/ef32dcd2cb69b69bc0c3e55205bce94a7def48d495358946bc42186dcccc/regex-2026.4.4-cp314-cp314t-win32.whl", hash = "sha256:385edaebde5db5be103577afc8699fea73a0e36a734ba24870be7ffa61119d74", size = 275709, upload-time = "2026-04-03T20:56:20.996Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/86/c291bf740945acbf35ed7dbebf8e2eea2f3f78041f6bd7cdab80cb274dc0/regex-2026.4.4-cp314-cp314t-win_amd64.whl", hash = "sha256:5d354b18839328927832e2fa5f7c95b7a3ccc39e7a681529e1685898e6436d45", size = 285622, upload-time = "2026-04-03T20:56:23.641Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/e7/ec846d560ae6a597115153c02ca6138a7877a1748b2072d9521c10a93e58/regex-2026.4.4-cp314-cp314t-win_arm64.whl", hash = "sha256:af0384cb01a33600c49505c27c6c57ab0b27bf84a74e28524c92ca897ebdac9d", size = 275773, upload-time = "2026-04-03T20:56:26.07Z" },
 ]
 
 [[package]]
@@ -783,6 +971,43 @@ wheels = [
 ]
 
 [[package]]
+name = "sqlfluff"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "chardet" },
+    { name = "click" },
+    { name = "colorama" },
+    { name = "diff-cover" },
+    { name = "jinja2" },
+    { name = "pathspec" },
+    { name = "platformdirs" },
+    { name = "pytest" },
+    { name = "pyyaml" },
+    { name = "regex" },
+    { name = "tblib" },
+    { name = "tqdm" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d5/c1/ffe7b97441b8a6febfb8288226344898944fa2007e93779607096e8bc93a/sqlfluff-4.1.0.tar.gz", hash = "sha256:83dd4c081afb48c0af861833015a18b13d52726bfe52a286246dbd7a64b7d111", size = 992214, upload-time = "2026-03-26T22:37:32.063Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4c/77/1b42179aa7d68baa665b4f42dce2d947c1acd6b19af0760d34423fdc591f/sqlfluff-4.1.0-py3-none-any.whl", hash = "sha256:ae11123ca4a697abadbd2783f85f04e58c36e7dd26ae8024f400efccc6a44631", size = 985010, upload-time = "2026-03-26T22:37:30.054Z" },
+]
+
+[[package]]
+name = "sqlfluff-templater-dbt"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dbt-core" },
+    { name = "jinja2-simple-tags" },
+    { name = "sqlfluff" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4f/25/18cca913ab9be3961dfedc534eaedaeaaaaefdfa4e1542f26b85a9db7679/sqlfluff_templater_dbt-4.1.0.tar.gz", hash = "sha256:18699aac09901d758a21c8b56236ddb6b9668517f87dd29e7b0cd1e3f4782ea6", size = 15503, upload-time = "2026-03-26T22:37:27.27Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9c/27/81aaadf9e1e084b94b2302121d05288cf755231509180e691d9dffae2d1f/sqlfluff_templater_dbt-4.1.0-py3-none-any.whl", hash = "sha256:81070ec4e78efb08a18ddbe4673e8ae0790ee91bf7c6a45bdba79c786f29a92c", size = 15166, upload-time = "2026-03-26T22:37:26.167Z" },
+]
+
+[[package]]
 name = "sqlparse"
 version = "0.5.3"
 source = { registry = "https://pypi.org/simple" }
@@ -792,12 +1017,33 @@ wheels = [
 ]
 
 [[package]]
+name = "tblib"
+version = "3.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f4/8a/14c15ae154895cc131174f858c707790d416c444fc69f93918adfd8c4c0b/tblib-3.2.2.tar.gz", hash = "sha256:e9a652692d91bf4f743d4a15bc174c0b76afc750fe8c7b6d195cc1c1d6d2ccec", size = 35046, upload-time = "2025-11-12T12:21:16.572Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/be/5d2d47b1fb58943194fb59dcf222f7c4e35122ec0ffe8c36e18b5d728f0b/tblib-3.2.2-py3-none-any.whl", hash = "sha256:26bdccf339bcce6a88b2b5432c988b266ebbe63a4e593f6b578b1d2e723d2b76", size = 12893, upload-time = "2025-11-12T12:21:14.407Z" },
+]
+
+[[package]]
 name = "text-unidecode"
 version = "1.3"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ab/e2/e9a00f0ccb71718418230718b3d900e71a5d16e701a3dae079a21e9cd8f8/text-unidecode-1.3.tar.gz", hash = "sha256:bad6603bb14d279193107714b288be206cac565dfa49aa5b105294dd5c4aab93", size = 76885, upload-time = "2019-08-30T21:36:45.405Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a6/a5/c0b6468d3824fe3fde30dbb5e1f687b291608f9473681bbf7dabbf5a87d7/text_unidecode-1.3-py2.py3-none-any.whl", hash = "sha256:1311f10e8b895935241623731c2ba64f4c455287888b18189350b67134a822e8", size = 78154, upload-time = "2019-08-30T21:37:03.543Z" },
+]
+
+[[package]]
+name = "tqdm"
+version = "4.67.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598, upload-time = "2026-02-03T17:35:53.048Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl", hash = "sha256:ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf", size = 78374, upload-time = "2026-02-03T17:35:50.982Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

Adds SQLFluff linting for dbt models on pull requests and pushes, wires a local `sqlfluff fix` pre-commit hook for edited SQL, and applies SQLFluff-driven formatting across staging and gold models. Pre-commit also switches ShellCheck to shellcheck-py (no Docker) and tightens YAML hooks so hooks stay green locally.

### Added

- GitHub Actions workflow `quality-sql.yaml` running `uv run sqlfluff lint` on dbt changes
- `scripts/sqlfluff-dbt-fix.sh` and SQLFluff-related dependencies in `services/dbt`

### Updated

- `.pre-commit-config.yaml` (SQLFluff hook, shellcheck-py, yamllint args)
- dbt SQL models formatted to satisfy SQLFluff rules