### PR TITLE
chore(backend): add shared fixture helpers

### DIFF
--- a/.agents/skills/add-backend-endpoint/SKILL.md
+++ b/.agents/skills/add-backend-endpoint/SKILL.md
@@ -262,29 +262,47 @@ Add integration tests in `services/backend/internal/grpc/{domain}_service_integr
 
 **How the DB container works** (`testmain_test.go`):
 
-`TestMain` starts a single ephemeral postgres container (testcontainers-go) before any test runs and terminates it after all tests finish. The container's connection string is stored in the `testDBConnStr` package-level variable. After `postgres.Run` returns, `TestMain` calls a `waitForDB` retry loop (up to 10s, 500ms intervals) to ensure postgres has truly finished running init scripts before any test connects. This means:
+`TestMain` calls `testinfra.Setup(ctx, "../sql/schema")`, which starts a single ephemeral `pgvector/pgvector:pg16` Postgres container, applies goose migrations, runs River migrations, starts Redis, and terminates everything after the package test run. This means:
 
 - No external postgres required — `make test-backend` is fully self-contained
 - Running tests never touches your local Tilt postgres
 - The container starts **once per `go test` invocation**, not once per test function
 
 **Per-test isolation: transaction rollback**
-Each `newTestCtx(t)` call opens a fresh `*sql.DB` connection and immediately begins a transaction. `db.New(tx)` is used because sqlc's `New()` accepts the `DBTX` interface, which both `*sql.DB` and `*sql.Tx` satisfy. `t.Cleanup` rolls back the transaction and closes the connection. Since the transaction is never committed, every write is discarded at cleanup — no truncation, no WAL writes.
+Each `newTestCtx(t)` call begins a fresh pgx transaction from the package test pool. `db.New(tx)` is used because sqlc's `New()` accepts the `DBTX` interface, which both `pgx.Tx` and `*pgxpool.Pool` satisfy. `t.Cleanup` rolls back the transaction. Since the transaction is never committed, every write is discarded at cleanup.
 
 One implication: if two records are inserted in the same `newTestCtx` transaction within the same millisecond, `ORDER BY created_at DESC` is non-deterministic. Use a map-based assertion or insert records in separate `newTestCtx` calls if ordering matters.
 
 **Shared setup** (`testhelpers_test.go`):
 
-- `newTestCtx(t)` — opens a connection, begins a transaction, registers `t.Cleanup` to roll back and close. Returns `(ctx context.Context, queries *db.Queries)`.
+- `newTestCtx(t)` — begins a pgx transaction, registers `t.Cleanup` to roll back, injects `queries` into context, and returns `(ctx context.Context, queries *db.Queries)`.
+- `newDirectQueries(t)` — returns sqlc queries on the shared pool for tests that must observe rows committed outside the test transaction.
 - `withAnalyzer(ctx, url)` — adds HTTP client and analyzer URL to ctx (for journal tests).
-- `mockAnalyzerServer(t)` / `failingAnalyzerServer(t)` — httptest servers with `t.Cleanup(srv.Close)` registered automatically.
-- `createTestUser(t, queries)` — inserts a minimal OAuth user and returns its UUID.
+- `withRiverDeps(ctx)` — adds the shared pgx pool and insert-only River client for handlers that enqueue jobs.
+- `testinfra.MockAnalyzerServer(t)` / `testinfra.FailingAnalyzerServer(t)` — httptest servers with `t.Cleanup(srv.Close)` registered automatically.
+- `createTestUser`, `createTestJournal`, `createTestGameBalance`, `createTestGameBet`, and `createTestCommunityUser` delegate to `internal/testfixtures`.
 
-**Schema** (`testdata/schema.sql`): mirrors `docker/db/01-bootstrap.sql` without seed data or unrelated databases (dagster, mlflow, etc.). Keep these in sync when adding new tables.
+**Fixture helpers** (`internal/testfixtures`):
+
+Use `testfixtures.CreateWithDefaults` for supported setup records instead of hand-writing sqlc params:
+
+```go
+user := testfixtures.CreateWithDefaults(t, ctx, queries, db.SourceUser{})
+journal := testfixtures.CreateWithDefaults(t, ctx, queries, db.SourceJournal{
+    UserID:      user.ID,
+    JournalText: "test body",
+    MoodScore:   testfixtures.Int32Ptr(7),
+})
+```
+
+Supported fixture models include users, journals, game balances/bets, journal exports, journal community projections, community rollups/summaries/prompt sets, and runtime config. Fixtures fill defaults, merge non-zero caller fields, recursively create supported parents when FKs are omitted, and fail loudly for invalid `fieldsToEmpty` names. Raw SQL is still appropriate for unsupported models or specialized database types, such as journal sentiments, journal topics, and pgvector embeddings.
+
+Community rollup `DeltaVsPrevious` defaults to invalid/NULL; pass `testfixtures.Numeric(t, "0")` when a test needs an explicit numeric zero.
 
 Key conventions:
 
 - Call `newTestCtx(t)` at the start of every test that touches the DB. Rollback on cleanup gives a clean slate automatically.
+- Use `testfixtures` or the shared helper wrappers for supported setup rows.
 - For tests that only check input validation (bad UUIDs, missing fields), use `context.Background()` directly — no DB setup needed.
 - Use `t.Run` for grouping related subtests within a single top-level test function (e.g., pagination variants, or multiple invalid input shapes). Each subtest that needs the DB calls `newTestCtx(t)` independently.
 - Log to `io.Discard` (the shared helpers do this automatically) — no `os.Stdout` or `slog.SetDefault` in tests.

--- a/.agents/skills/river-async-jobs/SKILL.md
+++ b/.agents/skills/river-async-jobs/SKILL.md
@@ -33,4 +33,23 @@ Every job needs two things, then one wiring step:
 
 - Workers hold their own deps (httpClient, logger, queries) as struct fields — they run outside gRPC context
 - `InsertTx` guarantees the job is rolled back if the transaction rolls back
-- Tests: use `jobs.NewInsertOnlyClient(testPgxPool)` to enqueue without processing; use a full client with `Subscribe(EventKindJobCompleted)` to test worker execution
+
+## Testing
+
+- Package tests use `testinfra.Setup(ctx, "../sql/schema")` from `services/backend/internal/testinfra` to start Postgres, apply goose migrations, run River migrations, and start Redis.
+- Use `jobs.NewInsertOnlyClient(testPgxPool)` or the shared `newInsertOnlyClient(t)` helper to enqueue without processing.
+- Use a full River client with `Subscribe(EventKindJobCompleted)` or `Subscribe(EventKindJobFailed)` to test worker execution.
+- Use `internal/testfixtures` for supported setup rows instead of hand-writing sqlc params. For example:
+
+```go
+q := db.New(testPgxPool)
+user := testfixtures.CreateWithDefaults(t, ctx, q, db.SourceUser{})
+journal := testfixtures.CreateWithDefaults(t, ctx, q, db.SourceJournal{
+    UserID:      user.ID,
+    JournalText: "entry to analyze",
+    MoodScore:   testfixtures.Int32Ptr(5),
+})
+```
+
+- Raw SQL is still fine for unsupported analysis tables such as `source.journal_sentiments` and `source.journal_topics`.
+- When verifying `InsertTx`, create the DB row and River job in the same pgx transaction, then assert both appear only after commit.

--- a/services/backend/AGENTS.md
+++ b/services/backend/AGENTS.md
@@ -145,6 +145,7 @@ func (s *UserServer) CreateUser(ctx context.Context, req *pb.CreateUserRequest) 
 - Integration tests: `*_integration_test.go` files
 - Use `testify` for assertions and test suites
 - Use `moq` for generating mock implementations
+- Use `internal/testfixtures` for integration-test database setup when a supported model exists
 
 ### Running Tests
 
@@ -220,11 +221,64 @@ make moq-generate
 
 Mocks are automatically regenerated via pre-commit hook when `internal/db/querier.go` or `internal/inject/inject.go` change (see `.pre-commit-config.yaml`).
 
+### Integration Test Infrastructure
+
+Shared integration infrastructure lives in `internal/testinfra`.
+
+- `testinfra.Setup(ctx, schemaDir)` starts a `pgvector/pgvector:pg16` PostgreSQL container, applies goose migrations from `internal/sql/schema`, runs River migrations, starts Redis, and returns a `*testinfra.TestDB`.
+- `TestDB` exposes `Pool *pgxpool.Pool`, `ConnStr`, an insert-only `RiverClient`, and a `RedisClient`.
+- `testinfra.ApplyExtraSQL` loads extra SQL fixtures, such as dbt-managed schemas used by analytics tests.
+- `testinfra.MockAnalyzerServer(t)` and `testinfra.FailingAnalyzerServer(t)` create analyzer HTTP test servers and register cleanup automatically.
+
+Package-level `TestMain` functions in `internal/grpc` and `internal/jobs` start the shared containers once per package test run. Most gRPC integration tests call `newTestCtx(t)`, which begins a pgx transaction, wraps it with `db.New(tx)`, injects the query object into context, and rolls the transaction back with `t.Cleanup`.
+
+Use `newDirectQueries(t)` only when the code under test commits outside the test transaction and the test needs to observe committed rows.
+
+### Fixture Helpers
+
+Database fixture helpers live in `internal/testfixtures`. Prefer them over hand-written `Create*Params`, upsert params, or raw SQL for supported setup records.
+
+Supported models:
+
+- `db.SourceUser`
+- `db.SourceJournal`
+- `db.SourceUserGameBalance`
+- `db.SourceUserGameBet`
+- `db.SourceJournalExport`
+- `db.SourceJournalCommunityProjection`
+- `db.SourceCommunityThemeRollup`
+- `db.SourceCommunityMoodRollup`
+- `db.SourceCommunitySummary`
+- `db.SourceCommunityPromptSet`
+- `db.SourceRuntimeConfig`
+
+Primary API:
+
+```go
+user := testfixtures.CreateWithDefaults(t, ctx, queries, db.SourceUser{})
+journal := testfixtures.CreateWithDefaults(t, ctx, queries, db.SourceJournal{
+    UserID:      user.ID,
+    JournalText: "A test journal entry",
+    MoodScore:   testfixtures.Int32Ptr(7),
+})
+```
+
+- `BuildDefaultModel(t, model)` returns defaults without persisting.
+- `Create(t, ctx, queries, model)` persists an already-populated supported model.
+- `CreateWithDefaults(t, ctx, queries, model, fieldsToEmpty...)` merges non-zero caller fields over defaults, resolves supported foreign keys, and persists.
+- `fieldsToEmpty` takes validated Go struct field names, e.g. `"MoodScore"`, for cases where a default is non-zero but the test needs the zero value.
+- FK-aware fixtures create parent users/journals when required IDs are omitted and respect existing FK values when supplied.
+- Community rollup `DeltaVsPrevious` defaults to invalid/NULL. Pass `testfixtures.Numeric(t, "0")` when a test needs a real numeric zero.
+
+Raw SQL is still acceptable in tests for unsupported models or specialized database types, such as journal sentiments, journal topics, and pgvector embeddings.
+
 ### Test Patterns
 
 - Use table-driven tests for multiple test cases
 - Mock external dependencies (HTTP clients, etc.)
-- Integration tests require PostgreSQL running
+- Validation-only tests should use `context.Background()` and avoid DB setup
+- Integration tests should use `newTestCtx(t)` plus `testfixtures` for supported database setup
+- Unit tests should keep explicit mocked sqlc params when those params are part of the behavior being asserted
 
 ## Configuration
 

--- a/services/backend/README.md
+++ b/services/backend/README.md
@@ -1,0 +1,108 @@
+# Backend Service
+
+Go gRPC backend with a grpc-gateway HTTP surface, sqlc-generated PostgreSQL access, River background jobs, Redis-backed caching, and testcontainers-based integration tests.
+
+## Development
+
+Common commands from the repository root:
+
+```bash
+make sqlc-generate
+make buf-generate
+make moq-generate
+```
+
+Or from this directory:
+
+```bash
+go test ./...
+go test -v ./internal/grpc
+go test -v ./internal/jobs
+```
+
+Generated files live under `internal/db`, `internal/pb`, and `internal/mocks`. Do not edit generated files directly.
+
+## Test Infrastructure
+
+Shared integration test infrastructure lives in `internal/testinfra`.
+
+`testinfra.Setup(ctx, schemaDir)` starts:
+
+- PostgreSQL via `pgvector/pgvector:pg16`
+- goose migrations from `internal/sql/schema`
+- River migrations and an insert-only River client
+- Redis via `redis:7-alpine`
+
+It returns a `*testinfra.TestDB` with:
+
+- `Pool *pgxpool.Pool`
+- `ConnStr string`
+- `RiverClient *river.Client[pgx.Tx]`
+- `RedisClient *redis.Client`
+
+Most gRPC integration tests use the package-level `TestMain` in `internal/grpc/testmain_test.go`, then call `newTestCtx(t)` from `internal/grpc/testhelpers_test.go`. `newTestCtx(t)` opens a fresh pgx transaction, wraps it with `db.New(tx)`, injects the query object into context, and rolls the transaction back in `t.Cleanup`.
+
+Use `newDirectQueries(t)` only when the code under test commits outside the test transaction and the test needs to observe committed rows.
+
+## Test Fixtures
+
+Database fixture helpers live in `internal/testfixtures`.
+
+Use them for DB setup in integration tests instead of hand-writing `Create*Params`, upsert params, or raw inserts for supported models:
+
+```go
+user := testfixtures.CreateWithDefaults(t, ctx, queries, db.SourceUser{})
+journal := testfixtures.CreateWithDefaults(t, ctx, queries, db.SourceJournal{
+    UserID:      user.ID,
+    JournalText: "A test journal entry",
+    MoodScore:   testfixtures.Int32Ptr(7),
+})
+```
+
+Supported models:
+
+- `db.SourceUser`
+- `db.SourceJournal`
+- `db.SourceUserGameBalance`
+- `db.SourceUserGameBet`
+- `db.SourceJournalExport`
+- `db.SourceJournalCommunityProjection`
+- `db.SourceCommunityThemeRollup`
+- `db.SourceCommunityMoodRollup`
+- `db.SourceCommunitySummary`
+- `db.SourceCommunityPromptSet`
+- `db.SourceRuntimeConfig`
+
+The main helpers are:
+
+- `BuildDefaultModel(t, model)` - returns a valid default model without persisting it
+- `Create(t, ctx, queries, model)` - persists an already-populated supported model
+- `CreateWithDefaults(t, ctx, queries, model, fieldsToEmpty...)` - fills defaults, merges non-zero fields, resolves supported foreign keys, then persists
+
+`fieldsToEmpty` uses Go struct field names and is validated. Use it when a default is normally non-zero but the test needs the zero value:
+
+```go
+journal := testfixtures.CreateWithDefaults(t, ctx, queries, db.SourceJournal{}, "MoodScore")
+```
+
+Foreign key behavior:
+
+- `SourceJournal`, game records, journal exports, and journal community projections create a parent user or journal when required IDs are omitted.
+- If an FK is supplied, the helper respects it and does not create an extra parent.
+
+Value conventions:
+
+- Unique fields use UUID suffixes for parallel-test safety.
+- Community rollup `DeltaVsPrevious` defaults to invalid/NULL. Pass `testfixtures.Numeric(t, "0")` when a test needs a real numeric zero.
+- Do not add faker/randomness to deterministic assertions. Prefer explicit values for ordering, ranking, embeddings, rollups, and enum-like fields.
+
+Unsupported models should fail at compile time where possible because the helper API is constrained to supported fixture models. Add sqlc insert/upsert queries before adding fixture support for new persisted models.
+
+## Test Style
+
+- Unit tests should use moq mocks and explicit generated params when those params are part of the behavior being asserted.
+- Integration tests should use `testfixtures` for supported setup rows.
+- Raw SQL in tests is acceptable for unsupported models or specialized database types, such as `journal_sentiments`, `journal_topics`, and pgvector embeddings.
+- Validation-only tests should use `context.Background()` and avoid DB setup.
+- Tests that need River dependencies should use `withRiverDeps(ctx)`.
+- Tests that need analyzer HTTP behavior should use `testinfra.MockAnalyzerServer(t)` or `testinfra.FailingAnalyzerServer(t)`.

--- a/services/backend/internal/grpc/analytics_service_integration_test.go
+++ b/services/backend/internal/grpc/analytics_service_integration_test.go
@@ -5,12 +5,10 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
-	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jyablonski/lotus/internal/db"
 	grpcServer "github.com/jyablonski/lotus/internal/grpc"
 	pb "github.com/jyablonski/lotus/internal/pb/proto/analytics"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 // createTestUserWithJournals creates a user with 5 journals for analytics testing.
@@ -19,13 +17,7 @@ func createTestUserWithJournals(t *testing.T, queries *db.Queries) uuid.UUID {
 	userID := createTestUser(t, queries)
 
 	for i := 0; i < 5; i++ {
-		ms := int32(3 + i)
-		_, err := queries.CreateJournal(context.Background(), db.CreateJournalParams{
-			UserID:      pgtype.UUID{Bytes: userID, Valid: true},
-			JournalText: "Test journal entry for analytics " + string(rune('A'+i)),
-			MoodScore:   &ms,
-		})
-		require.NoError(t, err)
+		createTestJournal(t, queries, userID, "Test journal entry for analytics "+string(rune('A'+i)), int32(3+i))
 	}
 
 	return userID

--- a/services/backend/internal/grpc/community_service_integration_test.go
+++ b/services/backend/internal/grpc/community_service_integration_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/jyablonski/lotus/internal/db"
 	grpcServer "github.com/jyablonski/lotus/internal/grpc"
 	pb "github.com/jyablonski/lotus/internal/pb/proto/community"
+	"github.com/jyablonski/lotus/internal/testfixtures"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -17,20 +18,12 @@ func TestCommunityServer_GetCommunityPulse_Integration(t *testing.T) {
 	ctx, queries := newTestCtx(t)
 	svc := &grpcServer.CommunityServer{}
 
-	userID := createTestUser(t, queries)
-	_, err := queries.UpdateCommunitySettingsByUserId(context.Background(), db.UpdateCommunitySettingsByUserIdParams{
-		ID:                     pgtype.UUID{Bytes: userID, Valid: true},
-		CommunityInsightsOptIn: true,
-		CommunityLocationOptIn: true,
-		CommunityCountryCode:   strp("US"),
-		CommunityRegionCode:    strp("US-CA"),
-	})
-	require.NoError(t, err)
+	userID := createTestCommunityUser(t, queries, strp("US"), strp("US-CA"))
 
 	now := time.Now().UTC()
 	bucketDate := pgtype.Date{Time: time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC), Valid: true}
 
-	_, err = queries.UpsertCommunityThemeRollup(context.Background(), db.UpsertCommunityThemeRollupParams{
+	testfixtures.CreateWithDefaults(t, context.Background(), queries, db.SourceCommunityThemeRollup{
 		BucketDate:      bucketDate,
 		TimeGrain:       "day",
 		ScopeType:       "global",
@@ -41,9 +34,8 @@ func TestCommunityServer_GetCommunityPulse_Integration(t *testing.T) {
 		Rank:            1,
 		DeltaVsPrevious: communityNumeric("0.1000"),
 	})
-	require.NoError(t, err)
 
-	_, err = queries.UpsertCommunityMoodRollup(context.Background(), db.UpsertCommunityMoodRollupParams{
+	testfixtures.CreateWithDefaults(t, context.Background(), queries, db.SourceCommunityMoodRollup{
 		BucketDate:      bucketDate,
 		TimeGrain:       "day",
 		ScopeType:       "global",
@@ -54,9 +46,8 @@ func TestCommunityServer_GetCommunityPulse_Integration(t *testing.T) {
 		Rank:            1,
 		DeltaVsPrevious: pgtype.Numeric{},
 	})
-	require.NoError(t, err)
 
-	_, err = queries.UpsertCommunitySummary(context.Background(), db.UpsertCommunitySummaryParams{
+	testfixtures.CreateWithDefaults(t, context.Background(), queries, db.SourceCommunitySummary{
 		BucketDate:       bucketDate,
 		TimeGrain:        "day",
 		ScopeType:        "global",
@@ -66,7 +57,6 @@ func TestCommunityServer_GetCommunityPulse_Integration(t *testing.T) {
 		SourceMoodNames:  []string{"steady"},
 		GenerationMethod: "template",
 	})
-	require.NoError(t, err)
 
 	resp, err := svc.GetCommunityPulse(ctx, &pb.GetCommunityPulseRequest{
 		ViewerUserId: userID.String(),
@@ -86,18 +76,12 @@ func TestCommunityServer_GetCommunityPrompts_Integration(t *testing.T) {
 	ctx, queries := newTestCtx(t)
 	svc := &grpcServer.CommunityServer{}
 
-	userID := createTestUser(t, queries)
-	_, err := queries.UpdateCommunitySettingsByUserId(context.Background(), db.UpdateCommunitySettingsByUserIdParams{
-		ID:                     pgtype.UUID{Bytes: userID, Valid: true},
-		CommunityInsightsOptIn: true,
-		CommunityLocationOptIn: false,
-	})
-	require.NoError(t, err)
+	userID := createTestCommunityUser(t, queries, nil, nil)
 
 	now := time.Now().UTC()
 	bucketDate := pgtype.Date{Time: time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC), Valid: true}
 
-	_, err = queries.UpsertCommunityThemeRollup(context.Background(), db.UpsertCommunityThemeRollupParams{
+	testfixtures.CreateWithDefaults(t, context.Background(), queries, db.SourceCommunityThemeRollup{
 		BucketDate:      bucketDate,
 		TimeGrain:       "day",
 		ScopeType:       "global",
@@ -108,9 +92,8 @@ func TestCommunityServer_GetCommunityPrompts_Integration(t *testing.T) {
 		Rank:            1,
 		DeltaVsPrevious: pgtype.Numeric{},
 	})
-	require.NoError(t, err)
 
-	_, err = queries.UpsertCommunityMoodRollup(context.Background(), db.UpsertCommunityMoodRollupParams{
+	testfixtures.CreateWithDefaults(t, context.Background(), queries, db.SourceCommunityMoodRollup{
 		BucketDate:      bucketDate,
 		TimeGrain:       "day",
 		ScopeType:       "global",
@@ -121,9 +104,8 @@ func TestCommunityServer_GetCommunityPrompts_Integration(t *testing.T) {
 		Rank:            1,
 		DeltaVsPrevious: pgtype.Numeric{},
 	})
-	require.NoError(t, err)
 
-	_, err = queries.UpsertCommunityPromptSet(context.Background(), db.UpsertCommunityPromptSetParams{
+	testfixtures.CreateWithDefaults(t, context.Background(), queries, db.SourceCommunityPromptSet{
 		BucketDate:       bucketDate,
 		TimeGrain:        "day",
 		ScopeType:        "global",
@@ -133,7 +115,6 @@ func TestCommunityServer_GetCommunityPrompts_Integration(t *testing.T) {
 		SourceMoodNames:  []string{"steady"},
 		GenerationMethod: "template",
 	})
-	require.NoError(t, err)
 
 	resp, err := svc.GetCommunityPrompts(ctx, &pb.GetCommunityPromptsRequest{
 		ViewerUserId:    userID.String(),

--- a/services/backend/internal/grpc/game_service_integration_test.go
+++ b/services/backend/internal/grpc/game_service_integration_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/jyablonski/lotus/internal/db"
 	grpcServer "github.com/jyablonski/lotus/internal/grpc"
 	"github.com/jyablonski/lotus/internal/inject"
 	pb "github.com/jyablonski/lotus/internal/pb/proto/game"
@@ -33,11 +32,7 @@ func TestIntegration_GetGameBalance(t *testing.T) {
 		userID := createTestUser(t, queries)
 		svc := &grpcServer.GameServer{}
 
-		_, err := queries.UpsertUserGameBalance(ctx, db.UpsertUserGameBalanceParams{
-			UserID:  integPgUUID(userID),
-			Balance: 250,
-		})
-		require.NoError(t, err)
+		createTestGameBalance(t, queries, userID, 250)
 
 		resp, err := svc.GetGameBalance(ctx, &pb.GetGameBalanceRequest{UserId: userID.String()})
 		require.NoError(t, err)
@@ -74,11 +69,7 @@ func TestIntegration_UpdateGameBalance(t *testing.T) {
 		userID := createTestUser(t, queries)
 		svc := &grpcServer.GameServer{}
 
-		_, err := queries.UpsertUserGameBalance(ctx, db.UpsertUserGameBalanceParams{
-			UserID:  integPgUUID(userID),
-			Balance: 100,
-		})
-		require.NoError(t, err)
+		createTestGameBalance(t, queries, userID, 100)
 
 		resp, err := svc.UpdateGameBalance(ctx, &pb.UpdateGameBalanceRequest{UserId: userID.String(), Balance: 75})
 		require.NoError(t, err)
@@ -106,17 +97,12 @@ func TestIntegration_RecordBets_AndGetBetHistory(t *testing.T) {
 	ctx, _ := newTestCtx(t)
 	ctx = withRiverDeps(ctx)
 
-	// Create user via sqlc so RecordBets' separate tx can see it; CASCADE removes bets/balance.
-	pq := db.New(testPgxPool)
-	email := "record-bets-" + t.Name() + "@test.example"
-	op := "test"
-	u, err := pq.CreateUserOauth(context.Background(), db.CreateUserOauthParams{
-		Email: email, OauthProvider: &op,
-	})
-	require.NoError(t, err)
-	userID := u.ID.String()
+	// Create user via the direct pool so RecordBets' separate tx can see it.
+	pq := newDirectQueries(t)
+	userUUID := createTestUser(t, pq)
+	userID := userUUID.String()
 	t.Cleanup(func() {
-		_ = pq.DeleteUserById(context.Background(), u.ID)
+		_ = pq.DeleteUserById(context.Background(), integPgUUID(userUUID))
 	})
 
 	svc := &grpcServer.GameServer{}
@@ -153,21 +139,10 @@ func TestIntegration_GetBetHistory(t *testing.T) {
 		userID := createTestUser(t, queries)
 		svc := &grpcServer.GameServer{}
 
-		_, err := queries.UpsertUserGameBalance(ctx, db.UpsertUserGameBalanceParams{
-			UserID:  integPgUUID(userID),
-			Balance: 1000,
-		})
-		require.NoError(t, err)
+		createTestGameBalance(t, queries, userID, 1000)
 
 		for i := 0; i < 5; i++ {
-			_, err := queries.InsertUserGameBet(ctx, db.InsertUserGameBetParams{
-				UserID:     integPgUUID(userID),
-				Zone:       "red",
-				Amount:     int32(10 + i),
-				RollResult: 7,
-				Payout:     int32(20 + i),
-			})
-			require.NoError(t, err)
+			createTestGameBet(t, queries, userID, "red", int32(10+i), 7, int32(20+i))
 		}
 
 		resp1, err := svc.GetBetHistory(ctx, &pb.GetBetHistoryRequest{UserId: userID.String(), Limit: 2, Offset: 0})

--- a/services/backend/internal/grpc/journal_service_integration_test.go
+++ b/services/backend/internal/grpc/journal_service_integration_test.go
@@ -104,13 +104,7 @@ func TestGetJournals(t *testing.T) {
 	svc := &grpcServer.JournalServer{}
 
 	userID := createTestUser(t, queries)
-	ms := int32(5)
-	_, err := queries.CreateJournal(context.Background(), db.CreateJournalParams{
-		UserID:      integPgUUID(userID),
-		JournalText: "Test journal entry",
-		MoodScore:   &ms,
-	})
-	require.NoError(t, err)
+	createTestJournal(t, queries, userID, "Test journal entry", 5)
 
 	resp, err := svc.GetJournals(ctx, &pb.GetJournalsRequest{UserId: userID.String()})
 	require.NoError(t, err)
@@ -131,13 +125,7 @@ func TestGetJournalsPagination(t *testing.T) {
 	userID := createTestUser(t, queries)
 
 	for i := 0; i < 5; i++ {
-		mood := int32(i + 1)
-		_, err := queries.CreateJournal(context.Background(), db.CreateJournalParams{
-			UserID:      integPgUUID(userID),
-			JournalText: "Test journal entry " + strconv.Itoa(i+1),
-			MoodScore:   &mood,
-		})
-		require.NoError(t, err)
+		createTestJournal(t, queries, userID, "Test journal entry "+strconv.Itoa(i+1), int32(i+1))
 	}
 
 	// First page
@@ -170,13 +158,7 @@ func TestGetJournalsPaginationDefaults(t *testing.T) {
 	userID := createTestUser(t, queries)
 
 	for i := 0; i < 2; i++ {
-		mood := int32(i + 1)
-		_, err := queries.CreateJournal(context.Background(), db.CreateJournalParams{
-			UserID:      integPgUUID(userID),
-			JournalText: "Test journal entry " + strconv.Itoa(i+1),
-			MoodScore:   &mood,
-		})
-		require.NoError(t, err)
+		createTestJournal(t, queries, userID, "Test journal entry "+strconv.Itoa(i+1), int32(i+1))
 	}
 
 	// No pagination params → defaults
@@ -200,13 +182,7 @@ func TestGetJournalsPaginationLimitEnforcement(t *testing.T) {
 	svc := &grpcServer.JournalServer{}
 
 	userID := createTestUser(t, queries)
-	ms := int32(5)
-	_, err := queries.CreateJournal(context.Background(), db.CreateJournalParams{
-		UserID:      integPgUUID(userID),
-		JournalText: "Test journal entry",
-		MoodScore:   &ms,
-	})
-	require.NoError(t, err)
+	createTestJournal(t, queries, userID, "Test journal entry", 5)
 
 	// Limit > 100 should be capped at 100
 	resp, err := svc.GetJournals(ctx, &pb.GetJournalsRequest{UserId: userID.String(), Limit: 200, Offset: 0})
@@ -221,13 +197,7 @@ func TestTriggerJournalAnalysis(t *testing.T) {
 	svc := &grpcServer.JournalServer{}
 
 	userID := createTestUser(t, queries)
-	ms := int32(6)
-	journal, err := queries.CreateJournal(context.Background(), db.CreateJournalParams{
-		UserID:      integPgUUID(userID),
-		JournalText: "Manual analysis test",
-		MoodScore:   &ms,
-	})
-	require.NoError(t, err)
+	journal := createTestJournal(t, queries, userID, "Manual analysis test", 6)
 
 	resp, err := svc.TriggerJournalAnalysis(ctx, &pb.TriggerAnalysisRequest{
 		JournalId: strconv.Itoa(int(journal.ID)),
@@ -309,13 +279,7 @@ func TestGetJournalByID(t *testing.T) {
 	svc := &grpcServer.JournalServer{}
 
 	userID := createTestUser(t, queries)
-	ms := int32(8)
-	row, err := queries.CreateJournal(context.Background(), db.CreateJournalParams{
-		UserID:      integPgUUID(userID),
-		JournalText: "Detail view body",
-		MoodScore:   &ms,
-	})
-	require.NoError(t, err)
+	row := createTestJournal(t, queries, userID, "Detail view body", 8)
 
 	resp, err := svc.GetJournal(ctx, &pb.GetJournalRequest{
 		JournalId: strconv.Itoa(int(row.ID)),

--- a/services/backend/internal/grpc/search_service_integration_test.go
+++ b/services/backend/internal/grpc/search_service_integration_test.go
@@ -10,6 +10,7 @@ import (
 	grpcServer "github.com/jyablonski/lotus/internal/grpc"
 	"github.com/jyablonski/lotus/internal/inject"
 	pb "github.com/jyablonski/lotus/internal/pb/proto/journal"
+	"github.com/jyablonski/lotus/internal/testfixtures"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -19,13 +20,11 @@ import (
 func insertSearchJournal(t *testing.T, userID uuid.UUID, text string, mood int32) int32 {
 	t.Helper()
 	q := db.New(testPgxPool)
-	ms := mood
-	j, err := q.CreateJournal(context.Background(), db.CreateJournalParams{
-		UserID:      pgtype.UUID{Bytes: userID, Valid: true},
+	j := testfixtures.CreateWithDefaults(t, context.Background(), q, db.SourceJournal{
+		UserID:      testfixtures.UUIDFromGoogle(t, userID),
 		JournalText: text,
-		MoodScore:   &ms,
+		MoodScore:   testfixtures.Int32Ptr(mood),
 	})
-	require.NoError(t, err)
 	t.Cleanup(func() {
 		_, _ = q.DeleteJournalForUser(context.Background(), db.DeleteJournalForUserParams{
 			ID:     j.ID,
@@ -39,12 +38,7 @@ func insertSearchJournal(t *testing.T, userID uuid.UUID, text string, mood int32
 func insertSearchUser(t *testing.T) uuid.UUID {
 	t.Helper()
 	q := db.New(testPgxPool)
-	email := "search-test-" + uuid.New().String() + "@test.example"
-	op := "test"
-	u, err := q.CreateUserOauth(context.Background(), db.CreateUserOauthParams{
-		Email: email, OauthProvider: &op,
-	})
-	require.NoError(t, err)
+	u := testfixtures.CreateWithDefaults(t, context.Background(), q, db.SourceUser{})
 	uid := uuid.UUID(u.ID.Bytes)
 	t.Cleanup(func() {
 		_ = q.DeleteUserById(context.Background(), u.ID)

--- a/services/backend/internal/grpc/search_service_test.go
+++ b/services/backend/internal/grpc/search_service_test.go
@@ -259,14 +259,8 @@ func TestSearchJournals_Success(t *testing.T) {
 	server := &internalgrpc.JournalServer{}
 	queries := newDirectQueries(t)
 	userID := createTestUser(t, queries)
-	mood := int32(7)
 
-	journal, err := queries.CreateJournal(context.Background(), db.CreateJournalParams{
-		UserID:      pgtype.UUID{Bytes: userID, Valid: true},
-		JournalText: "I need a little more rest this week.",
-		MoodScore:   &mood,
-	})
-	require.NoError(t, err)
+	journal := createTestJournal(t, queries, userID, "I need a little more rest this week.", 7)
 
 	vector := make([]float64, 384)
 	vector[0] = 0.25
@@ -274,7 +268,7 @@ func TestSearchJournals_Success(t *testing.T) {
 	vector[2] = 0.75
 	vectorSQL := vectorLiteral(vector)
 
-	_, err = testPgxPool.Exec(context.Background(),
+	_, err := testPgxPool.Exec(context.Background(),
 		`INSERT INTO source.journal_embeddings (journal_id, embedding, model_version) VALUES ($1, $2::public.vector, $3)`,
 		journal.ID, vectorSQL, "all-MiniLM-L6-v2",
 	)
@@ -327,14 +321,8 @@ func TestKeywordSearchJournals_Success(t *testing.T) {
 	server := &internalgrpc.JournalServer{}
 	queries := newDirectQueries(t)
 	userID := createTestUser(t, queries)
-	mood := int32(8)
 
-	journal, err := queries.CreateJournal(context.Background(), db.CreateJournalParams{
-		UserID:      pgtype.UUID{Bytes: userID, Valid: true},
-		JournalText: "I want to reset and rest before the weekend.",
-		MoodScore:   &mood,
-	})
-	require.NoError(t, err)
+	journal := createTestJournal(t, queries, userID, "I want to reset and rest before the weekend.", 8)
 
 	t.Cleanup(func() {
 		_, _ = queries.DeleteJournalForUser(context.Background(), db.DeleteJournalForUserParams{

--- a/services/backend/internal/grpc/testhelpers_test.go
+++ b/services/backend/internal/grpc/testhelpers_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/jyablonski/lotus/internal/db"
 	"github.com/jyablonski/lotus/internal/inject"
+	"github.com/jyablonski/lotus/internal/testfixtures"
 	"github.com/jyablonski/lotus/internal/testinfra"
 	"github.com/stretchr/testify/require"
 )
@@ -57,12 +58,45 @@ func withAnalyzer(ctx context.Context, url string) context.Context {
 // The insert runs within the test's transaction and is rolled back on cleanup.
 func createTestUser(t *testing.T, queries *db.Queries) uuid.UUID {
 	t.Helper()
-	email := "test-" + uuid.New().String() + "@test.example"
-	provider := "test"
-	user, err := queries.CreateUserOauth(context.Background(), db.CreateUserOauthParams{
-		Email:         email,
-		OauthProvider: &provider,
+	user := testfixtures.CreateWithDefaults(t, context.Background(), queries, db.SourceUser{})
+	return uuid.UUID(user.ID.Bytes)
+}
+
+func createTestJournal(t *testing.T, queries *db.Queries, userID uuid.UUID, text string, moodScore int32) db.SourceJournal {
+	t.Helper()
+	return testfixtures.CreateWithDefaults(t, context.Background(), queries, db.SourceJournal{
+		UserID:      testfixtures.UUIDFromGoogle(t, userID),
+		JournalText: text,
+		MoodScore:   testfixtures.Int32Ptr(moodScore),
 	})
-	require.NoError(t, err)
+}
+
+func createTestGameBalance(t *testing.T, queries *db.Queries, userID uuid.UUID, balance int32) db.SourceUserGameBalance {
+	t.Helper()
+	return testfixtures.CreateWithDefaults(t, context.Background(), queries, db.SourceUserGameBalance{
+		UserID:  testfixtures.UUIDFromGoogle(t, userID),
+		Balance: balance,
+	})
+}
+
+func createTestGameBet(t *testing.T, queries *db.Queries, userID uuid.UUID, zone string, amount, rollResult, payout int32) db.SourceUserGameBet {
+	t.Helper()
+	return testfixtures.CreateWithDefaults(t, context.Background(), queries, db.SourceUserGameBet{
+		UserID:     testfixtures.UUIDFromGoogle(t, userID),
+		Zone:       zone,
+		Amount:     amount,
+		RollResult: rollResult,
+		Payout:     payout,
+	})
+}
+
+func createTestCommunityUser(t *testing.T, queries *db.Queries, countryCode, regionCode *string) uuid.UUID {
+	t.Helper()
+	user := testfixtures.CreateWithDefaults(t, context.Background(), queries, db.SourceUser{
+		CommunityInsightsOptIn: true,
+		CommunityLocationOptIn: countryCode != nil || regionCode != nil,
+		CommunityCountryCode:   countryCode,
+		CommunityRegionCode:    regionCode,
+	})
 	return uuid.UUID(user.ID.Bytes)
 }

--- a/services/backend/internal/jobs/analyze_entry_test.go
+++ b/services/backend/internal/jobs/analyze_entry_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/jyablonski/lotus/internal/db"
 	"github.com/jyablonski/lotus/internal/jobs"
+	"github.com/jyablonski/lotus/internal/testfixtures"
 	"github.com/jyablonski/lotus/internal/testinfra"
 	"github.com/riverqueue/river"
 	"github.com/riverqueue/river/riverdriver/riverpgxv5"
@@ -36,10 +37,7 @@ func TestAnalyzeEntryInsertTx(t *testing.T) {
 	client := newInsertOnlyClient(t)
 
 	pq := db.New(testPgxPool)
-	email := "analyze-entry-tx-" + t.Name() + "@test.example"
-	op := "test"
-	u, err := pq.CreateUserOauth(ctx, db.CreateUserOauthParams{Email: email, OauthProvider: &op})
-	require.NoError(t, err)
+	u := testfixtures.CreateWithDefaults(t, ctx, pq, db.SourceUser{})
 	t.Cleanup(func() {
 		_ = pq.DeleteUserById(ctx, u.ID)
 	})
@@ -48,13 +46,11 @@ func TestAnalyzeEntryInsertTx(t *testing.T) {
 	require.NoError(t, err)
 	defer tx.Rollback(ctx) //nolint:errcheck
 
-	ms := int32(5)
-	journal, err := db.New(tx).CreateJournal(ctx, db.CreateJournalParams{
+	journal := testfixtures.CreateWithDefaults(t, ctx, db.New(tx), db.SourceJournal{
 		UserID:      u.ID,
 		JournalText: "tx test entry",
-		MoodScore:   &ms,
+		MoodScore:   testfixtures.Int32Ptr(5),
 	})
-	require.NoError(t, err)
 	journalID := journal.ID
 	t.Cleanup(func() {
 		_, _ = pq.DeleteJournalForUser(ctx, db.DeleteJournalForUserParams{

--- a/services/backend/internal/jobs/community_jobs_test.go
+++ b/services/backend/internal/jobs/community_jobs_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jyablonski/lotus/internal/db"
 	"github.com/jyablonski/lotus/internal/jobs"
+	"github.com/jyablonski/lotus/internal/testfixtures"
 	"github.com/jyablonski/lotus/internal/testinfra"
 	"github.com/riverqueue/river"
 	"github.com/riverqueue/river/riverdriver/riverpgxv5"
@@ -124,7 +125,7 @@ func TestRefreshCommunityRollupsWorkerPersistsRollupsSummaryAndPrompts(t *testin
 			"US-CA",
 		)
 		journalID := createJournal(t, ctx, userID, "Rollup seed", 8)
-		_, err := testQueries.UpsertJournalCommunityProjection(ctx, db.UpsertJournalCommunityProjectionParams{
+		testfixtures.CreateWithDefaults(t, ctx, testQueries, db.SourceJournalCommunityProjection{
 			JournalID:            journalID,
 			UserID:               userID,
 			EligibleForCommunity: true,
@@ -136,7 +137,6 @@ func TestRefreshCommunityRollupsWorkerPersistsRollupsSummaryAndPrompts(t *testin
 			RegionCode:           ptr("US-CA"),
 			AnalysisVersion:      "v1",
 		})
-		require.NoError(t, err)
 	}
 
 	workers := river.NewWorkers()
@@ -224,25 +224,26 @@ func TestRepairCommunityDataWorkerEnqueuesProjectionRefreshes(t *testing.T) {
 
 func createCommunityUser(t *testing.T, ctx context.Context, email string, insightsOptIn, locationOptIn bool, timezone, country, region string) pgtype.UUID {
 	t.Helper()
-	var userID pgtype.UUID
-	require.NoError(t, testPgxPool.QueryRow(ctx, `
-		INSERT INTO source.users (
-			email, oauth_provider, timezone, community_insights_opt_in, community_location_opt_in, community_country_code, community_region_code
-		) VALUES ($1, 'test', $2, $3, $4, $5, $6)
-		RETURNING id
-	`, email, timezone, insightsOptIn, locationOptIn, country, region).Scan(&userID))
-	return userID
+	user := testfixtures.CreateWithDefaults(t, ctx, testQueries, db.SourceUser{
+		Email:                  email,
+		OauthProvider:          ptr("test"),
+		Timezone:               timezone,
+		CommunityInsightsOptIn: insightsOptIn,
+		CommunityLocationOptIn: locationOptIn,
+		CommunityCountryCode:   ptr(country),
+		CommunityRegionCode:    ptr(region),
+	})
+	return user.ID
 }
 
 func createJournal(t *testing.T, ctx context.Context, userID pgtype.UUID, text string, moodScore int32) int32 {
 	t.Helper()
-	var journalID int32
-	require.NoError(t, testPgxPool.QueryRow(ctx, `
-		INSERT INTO source.journals (user_id, journal_text, mood_score)
-		VALUES ($1, $2, $3)
-		RETURNING id
-	`, userID, text, moodScore).Scan(&journalID))
-	return journalID
+	journal := testfixtures.CreateWithDefaults(t, ctx, testQueries, db.SourceJournal{
+		UserID:      userID,
+		JournalText: text,
+		MoodScore:   testfixtures.Int32Ptr(moodScore),
+	})
+	return journal.ID
 }
 
 func insertSentiment(t *testing.T, ctx context.Context, journalID int32, sentiment, modelVersion string) {

--- a/services/backend/internal/testfixtures/pgtype.go
+++ b/services/backend/internal/testfixtures/pgtype.go
@@ -1,0 +1,60 @@
+package testfixtures
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+func UUID(t *testing.T) pgtype.UUID {
+	t.Helper()
+	return UUIDFromGoogle(t, uuid.New())
+}
+
+func UUIDFromGoogle(t *testing.T, id uuid.UUID) pgtype.UUID {
+	t.Helper()
+
+	var pgID pgtype.UUID
+	if err := pgID.Scan(id.String()); err != nil {
+		t.Fatalf("testfixtures: scan uuid: %v", err)
+	}
+	return pgID
+}
+
+func TimestampNow() pgtype.Timestamp {
+	return pgtype.Timestamp{
+		Time:  time.Now().Truncate(time.Second),
+		Valid: true,
+	}
+}
+
+func Date(year int, month time.Month, day int) pgtype.Date {
+	return pgtype.Date{
+		Time:  time.Date(year, month, day, 0, 0, 0, 0, time.UTC),
+		Valid: true,
+	}
+}
+
+func Numeric(t *testing.T, value string) pgtype.Numeric {
+	t.Helper()
+
+	var numeric pgtype.Numeric
+	if err := numeric.Scan(value); err != nil {
+		t.Fatalf("testfixtures: scan numeric %q: %v", value, err)
+	}
+	return numeric
+}
+
+func StringPtr(value string) *string {
+	return &value
+}
+
+func Int32Ptr(value int32) *int32 {
+	return &value
+}
+
+func Float64Ptr(value float64) *float64 {
+	return &value
+}

--- a/services/backend/internal/testfixtures/testfixtures.go
+++ b/services/backend/internal/testfixtures/testfixtures.go
@@ -1,0 +1,414 @@
+package testfixtures
+
+import (
+	"context"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jyablonski/lotus/internal/db"
+)
+
+type Model interface {
+	db.SourceUser |
+		db.SourceJournal |
+		db.SourceUserGameBalance |
+		db.SourceUserGameBet |
+		db.SourceJournalExport |
+		db.SourceJournalCommunityProjection |
+		db.SourceCommunityThemeRollup |
+		db.SourceCommunityMoodRollup |
+		db.SourceCommunitySummary |
+		db.SourceCommunityPromptSet |
+		db.SourceRuntimeConfig
+}
+
+// BuildDefaultModel returns a valid baseline model without persisting it.
+func BuildDefaultModel[T Model](t *testing.T, model T) T {
+	t.Helper()
+
+	suffix := uuid.New().String()
+	today := Date(time.Now().Year(), time.Now().Month(), time.Now().Day())
+
+	switch any(model).(type) {
+	case db.SourceUser:
+		provider := "test"
+		return any(db.SourceUser{
+			Email:         "test-" + suffix + "@test.example",
+			OauthProvider: &provider,
+		}).(T)
+	case db.SourceJournal:
+		return any(db.SourceJournal{
+			JournalText: "test journal " + suffix,
+			MoodScore:   Int32Ptr(3),
+		}).(T)
+	case db.SourceUserGameBalance:
+		return any(db.SourceUserGameBalance{
+			Balance: 100,
+		}).(T)
+	case db.SourceUserGameBet:
+		return any(db.SourceUserGameBet{
+			Zone:       "safe",
+			Amount:     10,
+			RollResult: 50,
+			Payout:     20,
+		}).(T)
+	case db.SourceJournalExport:
+		return any(db.SourceJournalExport{
+			Format: db.SourceExportFormatMarkdown,
+			Status: db.SourceExportStatusPending,
+		}).(T)
+	case db.SourceJournalCommunityProjection:
+		return any(db.SourceJournalCommunityProjection{
+			EligibleForCommunity: true,
+			EntryLocalDate:       today,
+			PrimaryMood:          StringPtr("calm"),
+			PrimarySentiment:     StringPtr("positive"),
+			ThemeNames:           []string{"gratitude"},
+			AnalysisVersion:      "test-v1",
+		}).(T)
+	case db.SourceCommunityThemeRollup:
+		return any(db.SourceCommunityThemeRollup{
+			BucketDate:      today,
+			TimeGrain:       "day",
+			ScopeType:       "global",
+			ScopeValue:      "test-" + suffix,
+			ThemeName:       "gratitude",
+			EntryCount:      1,
+			UniqueUserCount: 1,
+			Rank:            1,
+		}).(T)
+	case db.SourceCommunityMoodRollup:
+		return any(db.SourceCommunityMoodRollup{
+			BucketDate:      today,
+			TimeGrain:       "day",
+			ScopeType:       "global",
+			ScopeValue:      "test-" + suffix,
+			MoodName:        "calm",
+			EntryCount:      1,
+			UniqueUserCount: 1,
+			Rank:            1,
+		}).(T)
+	case db.SourceCommunitySummary:
+		return any(db.SourceCommunitySummary{
+			BucketDate:       today,
+			TimeGrain:        "day",
+			ScopeType:        "global",
+			ScopeValue:       "test-" + suffix,
+			SummaryText:      "test community summary",
+			SourceThemeNames: []string{"gratitude"},
+			SourceMoodNames:  []string{"calm"},
+			GenerationMethod: "test",
+		}).(T)
+	case db.SourceCommunityPromptSet:
+		return any(db.SourceCommunityPromptSet{
+			BucketDate:       today,
+			TimeGrain:        "day",
+			ScopeType:        "global",
+			ScopeValue:       "test-" + suffix,
+			PromptSetJson:    []byte(`["What helped today?"]`),
+			SourceThemeNames: []string{"gratitude"},
+			SourceMoodNames:  []string{"calm"},
+			GenerationMethod: "test",
+		}).(T)
+	case db.SourceRuntimeConfig:
+		return any(db.SourceRuntimeConfig{
+			Key:         "test." + suffix,
+			Value:       []byte(`{"enabled":true}`),
+			Service:     "backend",
+			Description: "test runtime config",
+		}).(T)
+	default:
+		t.Fatalf("testfixtures: %T is not registered; add an insert query or fixture case", model)
+	}
+
+	var zero T
+	return zero
+}
+
+// Create persists a fully populated model using sqlc query methods.
+func Create[T Model](t *testing.T, ctx context.Context, q *db.Queries, model T) T {
+	t.Helper()
+
+	switch v := any(model).(type) {
+	case db.SourceUser:
+		return any(createUser(t, ctx, q, v)).(T)
+	case db.SourceJournal:
+		created, err := q.CreateJournal(ctx, db.CreateJournalParams{
+			UserID:      v.UserID,
+			JournalText: v.JournalText,
+			MoodScore:   v.MoodScore,
+		})
+		requireNoError(t, "CreateJournal", err)
+		return any(created).(T)
+	case db.SourceUserGameBalance:
+		created, err := q.UpsertUserGameBalance(ctx, db.UpsertUserGameBalanceParams{
+			UserID:  v.UserID,
+			Balance: v.Balance,
+		})
+		requireNoError(t, "UpsertUserGameBalance", err)
+		return any(created).(T)
+	case db.SourceUserGameBet:
+		created, err := q.InsertUserGameBet(ctx, db.InsertUserGameBetParams{
+			UserID:     v.UserID,
+			Zone:       v.Zone,
+			Amount:     v.Amount,
+			RollResult: v.RollResult,
+			Payout:     v.Payout,
+		})
+		requireNoError(t, "InsertUserGameBet", err)
+		return any(created).(T)
+	case db.SourceJournalExport:
+		created, err := q.CreateJournalExport(ctx, db.CreateJournalExportParams{
+			UserID: v.UserID,
+			Format: v.Format,
+		})
+		requireNoError(t, "CreateJournalExport", err)
+		return any(created).(T)
+	case db.SourceJournalCommunityProjection:
+		created, err := q.UpsertJournalCommunityProjection(ctx, db.UpsertJournalCommunityProjectionParams{
+			JournalID:            v.JournalID,
+			UserID:               v.UserID,
+			EligibleForCommunity: v.EligibleForCommunity,
+			EntryLocalDate:       v.EntryLocalDate,
+			PrimaryMood:          v.PrimaryMood,
+			PrimarySentiment:     v.PrimarySentiment,
+			ThemeNames:           v.ThemeNames,
+			CountryCode:          v.CountryCode,
+			RegionCode:           v.RegionCode,
+			AnalysisVersion:      v.AnalysisVersion,
+		})
+		requireNoError(t, "UpsertJournalCommunityProjection", err)
+		return any(created).(T)
+	case db.SourceCommunityThemeRollup:
+		created, err := q.UpsertCommunityThemeRollup(ctx, db.UpsertCommunityThemeRollupParams{
+			BucketDate:      v.BucketDate,
+			TimeGrain:       v.TimeGrain,
+			ScopeType:       v.ScopeType,
+			ScopeValue:      v.ScopeValue,
+			ThemeName:       v.ThemeName,
+			EntryCount:      v.EntryCount,
+			UniqueUserCount: v.UniqueUserCount,
+			Rank:            v.Rank,
+			DeltaVsPrevious: v.DeltaVsPrevious,
+		})
+		requireNoError(t, "UpsertCommunityThemeRollup", err)
+		return any(created).(T)
+	case db.SourceCommunityMoodRollup:
+		created, err := q.UpsertCommunityMoodRollup(ctx, db.UpsertCommunityMoodRollupParams{
+			BucketDate:      v.BucketDate,
+			TimeGrain:       v.TimeGrain,
+			ScopeType:       v.ScopeType,
+			ScopeValue:      v.ScopeValue,
+			MoodName:        v.MoodName,
+			EntryCount:      v.EntryCount,
+			UniqueUserCount: v.UniqueUserCount,
+			Rank:            v.Rank,
+			DeltaVsPrevious: v.DeltaVsPrevious,
+		})
+		requireNoError(t, "UpsertCommunityMoodRollup", err)
+		return any(created).(T)
+	case db.SourceCommunitySummary:
+		created, err := q.UpsertCommunitySummary(ctx, db.UpsertCommunitySummaryParams{
+			BucketDate:       v.BucketDate,
+			TimeGrain:        v.TimeGrain,
+			ScopeType:        v.ScopeType,
+			ScopeValue:       v.ScopeValue,
+			SummaryText:      v.SummaryText,
+			SourceThemeNames: v.SourceThemeNames,
+			SourceMoodNames:  v.SourceMoodNames,
+			GenerationMethod: v.GenerationMethod,
+		})
+		requireNoError(t, "UpsertCommunitySummary", err)
+		return any(created).(T)
+	case db.SourceCommunityPromptSet:
+		created, err := q.UpsertCommunityPromptSet(ctx, db.UpsertCommunityPromptSetParams{
+			BucketDate:       v.BucketDate,
+			TimeGrain:        v.TimeGrain,
+			ScopeType:        v.ScopeType,
+			ScopeValue:       v.ScopeValue,
+			PromptSetJson:    v.PromptSetJson,
+			SourceThemeNames: v.SourceThemeNames,
+			SourceMoodNames:  v.SourceMoodNames,
+			GenerationMethod: v.GenerationMethod,
+		})
+		requireNoError(t, "UpsertCommunityPromptSet", err)
+		return any(created).(T)
+	case db.SourceRuntimeConfig:
+		created, err := q.UpsertRuntimeConfigValue(ctx, db.UpsertRuntimeConfigValueParams{
+			Key:         v.Key,
+			Value:       v.Value,
+			Service:     v.Service,
+			Description: v.Description,
+		})
+		requireNoError(t, "UpsertRuntimeConfigValue", err)
+		return any(created).(T)
+	default:
+		t.Fatalf("testfixtures: %T is not registered; add an insert query or fixture case", model)
+	}
+
+	var zero T
+	return zero
+}
+
+// CreateWithDefaults merges caller-provided fields over defaults, resolves
+// required parent records, and persists the resulting model.
+func CreateWithDefaults[T Model](t *testing.T, ctx context.Context, q *db.Queries, model T, fieldsToEmpty ...string) T {
+	t.Helper()
+
+	merged := BuildDefaultModel(t, model)
+	mergeNonZeroFields(t, &merged, model, fieldsToEmpty)
+	resolveDependencies(t, ctx, q, &merged)
+
+	return Create(t, ctx, q, merged)
+}
+
+func createUser(t *testing.T, ctx context.Context, q *db.Queries, user db.SourceUser) db.SourceUser {
+	t.Helper()
+
+	var created db.SourceUser
+	if user.OauthProvider != nil {
+		var err error
+		created, err = q.CreateUserOauth(ctx, db.CreateUserOauthParams{
+			Email:         user.Email,
+			OauthProvider: user.OauthProvider,
+		})
+		requireNoError(t, "CreateUserOauth", err)
+	} else {
+		var err error
+		created, err = q.CreateUser(ctx, db.CreateUserParams{
+			Email:    user.Email,
+			Password: user.Password,
+			Salt:     user.Salt,
+		})
+		requireNoError(t, "CreateUser", err)
+	}
+
+	if user.Timezone != "" {
+		var err error
+		created, err = q.UpdateUserTimezone(ctx, db.UpdateUserTimezoneParams{
+			ID:       created.ID,
+			Timezone: user.Timezone,
+		})
+		requireNoError(t, "UpdateUserTimezone", err)
+	}
+
+	if user.CommunityInsightsOptIn || user.CommunityLocationOptIn || user.CommunityCountryCode != nil || user.CommunityRegionCode != nil {
+		var err error
+		created, err = q.UpdateCommunitySettingsByUserId(ctx, db.UpdateCommunitySettingsByUserIdParams{
+			ID:                     created.ID,
+			CommunityInsightsOptIn: user.CommunityInsightsOptIn,
+			CommunityLocationOptIn: user.CommunityLocationOptIn,
+			CommunityCountryCode:   user.CommunityCountryCode,
+			CommunityRegionCode:    user.CommunityRegionCode,
+		})
+		requireNoError(t, "UpdateCommunitySettingsByUserId", err)
+	}
+
+	return created
+}
+
+func resolveDependencies[T Model](t *testing.T, ctx context.Context, q *db.Queries, model *T) {
+	t.Helper()
+
+	switch v := any(model).(type) {
+	case *db.SourceJournal:
+		if isZeroUUID(v.UserID) {
+			user := CreateWithDefaults(t, ctx, q, db.SourceUser{})
+			v.UserID = user.ID
+		}
+	case *db.SourceUserGameBalance:
+		if isZeroUUID(v.UserID) {
+			user := CreateWithDefaults(t, ctx, q, db.SourceUser{})
+			v.UserID = user.ID
+		}
+	case *db.SourceUserGameBet:
+		if isZeroUUID(v.UserID) {
+			user := CreateWithDefaults(t, ctx, q, db.SourceUser{})
+			v.UserID = user.ID
+		}
+	case *db.SourceJournalExport:
+		if isZeroUUID(v.UserID) {
+			user := CreateWithDefaults(t, ctx, q, db.SourceUser{})
+			v.UserID = user.ID
+		}
+	case *db.SourceJournalCommunityProjection:
+		if v.JournalID == 0 {
+			journal := CreateWithDefaults(t, ctx, q, db.SourceJournal{UserID: v.UserID})
+			v.JournalID = journal.ID
+			v.UserID = journal.UserID
+			return
+		}
+		if isZeroUUID(v.UserID) {
+			t.Fatalf("testfixtures: SourceJournalCommunityProjection requires UserID when JournalID is supplied")
+		}
+	}
+}
+
+func mergeNonZeroFields[T Model](t *testing.T, target *T, input T, fieldsToEmpty []string) {
+	t.Helper()
+
+	targetValue := reflect.ValueOf(target)
+	if targetValue.Kind() != reflect.Pointer || targetValue.Elem().Kind() != reflect.Struct {
+		t.Fatalf("testfixtures: merge target must be a pointer to a struct, got %T", target)
+	}
+
+	inputValue := reflect.ValueOf(input)
+	if inputValue.Kind() != reflect.Struct {
+		t.Fatalf("testfixtures: merge input must be a struct, got %T", input)
+	}
+
+	targetStruct := targetValue.Elem()
+	emptyFields := fieldsToEmptySet(t, inputValue.Type(), fieldsToEmpty)
+	for i := 0; i < inputValue.NumField(); i++ {
+		fieldInfo := inputValue.Type().Field(i)
+		if fieldInfo.PkgPath != "" {
+			continue
+		}
+
+		targetField := targetStruct.Field(i)
+		if !targetField.CanSet() {
+			continue
+		}
+
+		if emptyFields[fieldInfo.Name] {
+			targetField.Set(reflect.Zero(targetField.Type()))
+			continue
+		}
+
+		inputField := inputValue.Field(i)
+		if !inputField.IsZero() {
+			targetField.Set(inputField)
+		}
+	}
+}
+
+func fieldsToEmptySet(t *testing.T, typ reflect.Type, fieldNames []string) map[string]bool {
+	t.Helper()
+
+	fields := make(map[string]bool, len(fieldNames))
+	for _, name := range fieldNames {
+		field, ok := typ.FieldByName(name)
+		if !ok || field.PkgPath != "" {
+			t.Fatalf("testfixtures: %s has no exported field %q", typ.Name(), name)
+		}
+		fields[name] = true
+	}
+	return fields
+}
+
+func isZeroUUID(id pgtype.UUID) bool {
+	if !id.Valid {
+		return true
+	}
+	return id.Bytes == [16]byte{}
+}
+
+func requireNoError(t *testing.T, op string, err error) {
+	t.Helper()
+	if err != nil {
+		t.Fatalf("testfixtures: %s: %v", op, err)
+	}
+}

--- a/services/backend/internal/testfixtures/testfixtures_test.go
+++ b/services/backend/internal/testfixtures/testfixtures_test.go
@@ -1,0 +1,134 @@
+package testfixtures_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/jyablonski/lotus/internal/db"
+	"github.com/jyablonski/lotus/internal/testfixtures"
+	"github.com/jyablonski/lotus/internal/testinfra"
+	"github.com/stretchr/testify/require"
+)
+
+var testPool *pgxpool.Pool
+
+func TestMain(m *testing.M) {
+	ctx := context.Background()
+
+	testDB, err := testinfra.Setup(ctx, "../sql/schema")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "testinfra setup: %v\n", err)
+		os.Exit(1)
+	}
+
+	testPool = testDB.Pool
+	code := m.Run()
+	testDB.Close(ctx)
+	os.Exit(code)
+}
+
+func TestCreateWithDefaultsUser(t *testing.T) {
+	ctx, queries := newTestQueries(t)
+
+	user := testfixtures.CreateWithDefaults(t, ctx, queries, db.SourceUser{})
+
+	require.True(t, user.ID.Valid)
+	require.NotEmpty(t, user.Email)
+	require.NotNil(t, user.OauthProvider)
+	require.Equal(t, "test", *user.OauthProvider)
+}
+
+func TestCreateWithDefaultsJournalCreatesParentUser(t *testing.T) {
+	ctx, queries := newTestQueries(t)
+
+	journal := testfixtures.CreateWithDefaults(t, ctx, queries, db.SourceJournal{})
+
+	require.NotZero(t, journal.ID)
+	require.True(t, journal.UserID.Valid)
+	require.NotEmpty(t, journal.JournalText)
+	require.NotNil(t, journal.MoodScore)
+	require.EqualValues(t, 3, *journal.MoodScore)
+}
+
+func TestCreateWithDefaultsPreservesInputFields(t *testing.T) {
+	ctx, queries := newTestQueries(t)
+
+	user := testfixtures.CreateWithDefaults(t, ctx, queries, db.SourceUser{})
+	journal := testfixtures.CreateWithDefaults(t, ctx, queries, db.SourceJournal{
+		UserID:      user.ID,
+		JournalText: "caller supplied text",
+		MoodScore:   testfixtures.Int32Ptr(5),
+	})
+
+	require.Equal(t, user.ID, journal.UserID)
+	require.Equal(t, "caller supplied text", journal.JournalText)
+	require.NotNil(t, journal.MoodScore)
+	require.EqualValues(t, 5, *journal.MoodScore)
+}
+
+func TestCreateWithDefaultsCanForceFieldToZero(t *testing.T) {
+	ctx, queries := newTestQueries(t)
+
+	journal := testfixtures.CreateWithDefaults(t, ctx, queries, db.SourceJournal{}, "MoodScore")
+
+	require.Nil(t, journal.MoodScore)
+}
+
+func TestCreateWithDefaultsCreatesDependentRecords(t *testing.T) {
+	ctx, queries := newTestQueries(t)
+
+	balance := testfixtures.CreateWithDefaults(t, ctx, queries, db.SourceUserGameBalance{})
+	bet := testfixtures.CreateWithDefaults(t, ctx, queries, db.SourceUserGameBet{UserID: balance.UserID})
+	export := testfixtures.CreateWithDefaults(t, ctx, queries, db.SourceJournalExport{UserID: balance.UserID})
+	projection := testfixtures.CreateWithDefaults(t, ctx, queries, db.SourceJournalCommunityProjection{UserID: balance.UserID})
+
+	require.True(t, balance.UserID.Valid)
+	require.Equal(t, balance.UserID, bet.UserID)
+	require.Equal(t, balance.UserID, export.UserID)
+	require.Equal(t, balance.UserID, projection.UserID)
+	require.NotZero(t, projection.JournalID)
+}
+
+func TestCreateWithDefaultsCommunityRollups(t *testing.T) {
+	ctx, queries := newTestQueries(t)
+
+	theme := testfixtures.CreateWithDefaults(t, ctx, queries, db.SourceCommunityThemeRollup{})
+	mood := testfixtures.CreateWithDefaults(t, ctx, queries, db.SourceCommunityMoodRollup{})
+	summary := testfixtures.CreateWithDefaults(t, ctx, queries, db.SourceCommunitySummary{})
+	promptSet := testfixtures.CreateWithDefaults(t, ctx, queries, db.SourceCommunityPromptSet{})
+	runtimeConfig := testfixtures.CreateWithDefaults(t, ctx, queries, db.SourceRuntimeConfig{})
+
+	require.NotZero(t, theme.ID)
+	require.False(t, theme.DeltaVsPrevious.Valid)
+	require.NotZero(t, mood.ID)
+	require.False(t, mood.DeltaVsPrevious.Valid)
+	require.NotZero(t, summary.ID)
+	require.NotZero(t, promptSet.ID)
+	require.NotZero(t, runtimeConfig.ID)
+}
+
+func TestCreateWithDefaultsPreservesExplicitCommunityDelta(t *testing.T) {
+	ctx, queries := newTestQueries(t)
+
+	theme := testfixtures.CreateWithDefaults(t, ctx, queries, db.SourceCommunityThemeRollup{
+		DeltaVsPrevious: testfixtures.Numeric(t, "0"),
+	})
+
+	require.True(t, theme.DeltaVsPrevious.Valid)
+}
+
+func newTestQueries(t *testing.T) (context.Context, *db.Queries) {
+	t.Helper()
+
+	tx, err := testPool.Begin(context.Background())
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		_ = tx.Rollback(context.Background())
+	})
+
+	return context.Background(), db.New(tx)
+}


### PR DESCRIPTION
## Description

Adds shared backend database fixture helpers and updates integration tests to use them for supported setup rows.

### Added

- Backend testfixtures package for defaulted sqlc model creation
- Backend README guidance for testinfra and fixtures

### Updated

- gRPC and jobs integration tests to use shared setup helpers
- Backend AGENTS and skills docs with fixture/testinfra usage