### PR TITLE
ci(django): validate migrations in workflow before tests

### DIFF
--- a/.github/workflows/django.yaml
+++ b/.github/workflows/django.yaml
@@ -50,6 +50,17 @@ jobs:
       - name: Start Services
         run: make start-postgres
 
+      # `django_migration_ci` is created empty in docker/db/01-bootstrap.sql (not the seeded `postgres` DB).
+      - name: Django check and migrations
+        working-directory: services/django
+        env:
+          DB_NAME: django_migration_ci
+        run: |
+          set -euxo pipefail
+          uv run python manage.py check --database default
+          uv run python manage.py makemigrations --check --noinput
+          uv run python manage.py migrate --noinput
+
       - name: Run Test Suite
         working-directory: services/django
         run: uv run pytest --cov-fail-under=${COVERAGE_THRESHOLD}

--- a/docker/db/01-bootstrap.sql
+++ b/docker/db/01-bootstrap.sql
@@ -2,7 +2,7 @@ CREATE DATABASE dagster;
 CREATE DATABASE mlflow;
 CREATE DATABASE feast;
 CREATE DATABASE pact_broker;
--- Empty DB for Django CI: migrate from scratch without colliding with docker/db seed on `postgres`.
+-- Empty DB for django CI validation; separate from seeded `postgres`.
 CREATE DATABASE django_migration_ci;
 CREATE SCHEMA source;
 CREATE SCHEMA silver;
@@ -13,3 +13,7 @@ SET search_path TO source;
 CREATE EXTENSION IF NOT EXISTS "uuid-ossp" SCHEMA public;
 -- vector must live in public so the type is visible regardless of search_path
 CREATE EXTENSION IF NOT EXISTS vector SCHEMA public;
+
+-- create source schema in django migration ci database so it can run migrations
+\connect django_migration_ci
+CREATE SCHEMA IF NOT EXISTS source;

--- a/docker/db/01-bootstrap.sql
+++ b/docker/db/01-bootstrap.sql
@@ -2,6 +2,8 @@ CREATE DATABASE dagster;
 CREATE DATABASE mlflow;
 CREATE DATABASE feast;
 CREATE DATABASE pact_broker;
+-- Empty DB for Django CI: migrate from scratch without colliding with docker/db seed on `postgres`.
+CREATE DATABASE django_migration_ci;
 CREATE SCHEMA source;
 CREATE SCHEMA silver;
 CREATE SCHEMA gold;


### PR DESCRIPTION
## Description

Runs Django `check`, `makemigrations --check`, and `migrate` against an empty Postgres database (`django_migration_ci`) before pytest, so CI catches missing migrations and broken migration chains without migrating the seeded `postgres` DB.

### Added

- Empty `django_migration_ci` database in `docker/db/01-bootstrap.sql` for Django migration validation.

### Updated

- Django CI workflow runs system checks plus migration verification before the test suite, using `DB_NAME=django_migration_ci`.