### PR TITLE
ci(backend): add go quality checks workflow

### DIFF
--- a/.github/workflows/quality-go.yaml
+++ b/.github/workflows/quality-go.yaml
@@ -1,0 +1,64 @@
+name: Go Quality Checks
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "services/backend/**"
+      - ".github/workflows/quality-go.yaml"
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "services/backend/**"
+      - ".github/workflows/quality-go.yaml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  quality:
+    name: Go quality
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+        with:
+          sparse-checkout: |
+            services/backend/**
+          sparse-checkout-cone-mode: false
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.25"
+          cache-dependency-path: services/backend/go.sum
+
+      - name: Verify formatting (gofmt)
+        working-directory: services/backend
+        run: |
+          set -euo pipefail
+          unformatted="$(gofmt -l -s .)"
+          if [ -n "$unformatted" ]; then
+            echo "The following files are not formatted with gofmt -s:"
+            echo "$unformatted"
+            exit 1
+          fi
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v9
+        with:
+          version: v2.12.1
+          working-directory: services/backend
+
+      - name: Install deadcode
+        run: go install golang.org/x/tools/cmd/deadcode@v0.44.0
+
+      - name: Run deadcode
+        working-directory: services/backend
+        run: deadcode -test -tags contract ./...

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -62,9 +62,7 @@ repos:
       # deadcode traces all reachable symbols from main + test entry points and flags unexported functions/types with no callers
       - id: go-deadcode
         name: deadcode (backend)
-        entry:
-          bash -c 'cd services/backend && $(go env GOPATH)/bin/deadcode -test
-          ./...'
+        entry: bash -c 'cd services/backend && "$(go env GOPATH)/bin/deadcode" -test -tags contract ./...'
         language: system
         files: ^services/backend/.*\.go$
         pass_filenames: false

--- a/services/backend/.golangci.yml
+++ b/services/backend/.golangci.yml
@@ -28,9 +28,8 @@ linters:
     gocritic:
       disabled-checks:
         - exitAfterDefer
-
-issues:
-  exclude-dirs:
-    - internal/pb
-    - internal/mocks
-    - internal/db
+  exclusions:
+    paths:
+      - internal/pb
+      - internal/mocks
+      - internal/db

--- a/services/backend/internal/testfixtures/pgtype.go
+++ b/services/backend/internal/testfixtures/pgtype.go
@@ -8,11 +8,6 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
-func UUID(t *testing.T) pgtype.UUID {
-	t.Helper()
-	return UUIDFromGoogle(t, uuid.New())
-}
-
 func UUIDFromGoogle(t *testing.T, id uuid.UUID) pgtype.UUID {
 	t.Helper()
 
@@ -21,13 +16,6 @@ func UUIDFromGoogle(t *testing.T, id uuid.UUID) pgtype.UUID {
 		t.Fatalf("testfixtures: scan uuid: %v", err)
 	}
 	return pgID
-}
-
-func TimestampNow() pgtype.Timestamp {
-	return pgtype.Timestamp{
-		Time:  time.Now().Truncate(time.Second),
-		Valid: true,
-	}
 }
 
 func Date(year int, month time.Month, day int) pgtype.Date {
@@ -52,9 +40,5 @@ func StringPtr(value string) *string {
 }
 
 func Int32Ptr(value int32) *int32 {
-	return &value
-}
-
-func Float64Ptr(value float64) *float64 {
 	return &value
 }


### PR DESCRIPTION
## Description

Adds a path-filtered GitHub Actions workflow for the Go backend so CI enforces the same style and static checks developers already run via pre-commit. Removes unused testfixture helpers surfaced by deadcode.

### Added

- `.github/workflows/quality-go.yaml` running gofmt, golangci-lint, and deadcode on `services/backend/**` changes

### Updated

- Pre-commit `deadcode` hook now passes `-tags contract` for parity with CI

### Deleted

- Unused helpers in `internal/testfixtures/pgtype.go` reported by deadcode (`UUID`, `TimestampNow`, `Float64Ptr`)