### PR TITLE
chore(analyzer): bake embedding model into image

### DIFF
--- a/.claude/skills/create-pr
+++ b/.claude/skills/create-pr
@@ -1,1 +1,0 @@
-../../.agents/skills/create-pr

--- a/README.md
+++ b/README.md
@@ -148,18 +148,3 @@ graph LR
 
 - **dbt** - Data transformation and modeling tool to structure and prepare data for analysis and reporting
 - **Dagster** - Orchestration tool to manage and schedule data workflows and pipelines
-
-## Testing
-
-The project uses a multi-layered testing strategy to ensure correctness at every level, from individual functions to cross-service boundaries.
-
-**Unit & Integration Tests** — Each service has its own unit and integration tests that run as part of its dedicated CI/CD workflow. These form the foundation of the test suite and catch the majority of bugs with fast feedback loops.
-
-- Go and Python services use [Testcontainers](https://testcontainers.com/) to spin up a real Postgres instance per test run, eliminating the need for mocks at the database layer and keeping integration tests self-contained.
-- In CI, coverage is uploaded to [Coveralls](https://coveralls.io/) on every run for tracking and PR-level delta reporting, and a minimum coverage threshold is enforced as a required check before merging.
-
-**Contract Tests** — Consumer-driven contract tests using [Pact](https://pact.io/) verify that services agree on the shape of data exchanged between them. Consumer services (frontend, backend) generate pact files defining their expectations, and provider services verify they satisfy those contracts. These run in a dedicated workflow triggered by changes to any service involved in a contract, or by adding the `contract-tests` label to a PR.
-
-**End-to-End Tests** — Playwright-based E2E tests run against the frontend and verify complete user flows across the full stack (Docker Compose). On GitHub Actions, the dedicated **E2E** workflow (`.github/workflows/e2e.yaml`) runs on pull requests when changes land under `services/backend/`, `services/frontend/`, `services/analyzer/`, `services/django/`, or `docker/`.
-
-**Load Tests** — [k6](https://k6.io/) load tests target the backend service to validate performance characteristics and ensure the system holds up under concurrent usage.

--- a/services/analyzer/Dockerfile
+++ b/services/analyzer/Dockerfile
@@ -1,7 +1,9 @@
 FROM python:3.13-slim AS base
 
 ENV DEBIAN_FRONTEND=noninteractive \
+    HF_HOME=/app/.cache/huggingface \
     PATH="/app/.venv/bin:$PATH" \
+    SENTENCE_TRANSFORMERS_HOME=/app/.cache/sentence-transformers \
     UV_COMPILE_BYTECODE=1 \
     UV_PYTHON_DOWNLOADS=never \
     UV_LINK_MODE=copy
@@ -27,14 +29,21 @@ RUN if [ "$INSTALL_DEV_DEPENDENCIES" = "true" ]; then \
         uv sync --locked --no-dev --no-install-project; \
     fi
 
+RUN /app/.venv/bin/python -c "from sentence_transformers import SentenceTransformer; SentenceTransformer('all-MiniLM-L6-v2')"
+
 # ─── runtime ───────────────────────────────────────────────────────────────────
 FROM base AS runtime
 
+ENV HF_HUB_OFFLINE=1 \
+    TRANSFORMERS_OFFLINE=1
+
 WORKDIR /app
 
-RUN useradd --create-home appuser
+RUN groupadd --gid 10001 appuser && \
+    useradd --uid 10001 --gid 10001 --create-home appuser
 
-COPY --link --from=deps /app/.venv /app/.venv
+COPY --from=deps /app/.venv /app/.venv
+COPY --chown=10001:10001 --from=deps /app/.cache /app/.cache
 
 USER appuser
 

--- a/services/analyzer/pyproject.toml
+++ b/services/analyzer/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "pydantic-settings>=2.10.1",
     "sentence-transformers>=3.0.0",
     "sqlalchemy>=2.0.41",
+    "torch>=2.0.0",
 ]
 
 [dependency-groups]
@@ -33,6 +34,16 @@ local = [
     "ruff>=0.12.4",
     "ty>=0.0.33",
 ]
+
+[tool.uv.sources]
+torch = [
+    { index = "pytorch-cpu" },
+]
+
+[[tool.uv.index]]
+name = "pytorch-cpu"
+url = "https://download.pytorch.org/whl/cpu"
+explicit = true
 
 [tool.pytest.ini_options]
 filterwarnings = [

--- a/services/analyzer/src/clients/embedding_client.py
+++ b/services/analyzer/src/clients/embedding_client.py
@@ -1,4 +1,5 @@
 import logging
+import os
 
 from sentence_transformers import SentenceTransformer
 
@@ -16,10 +17,25 @@ class EmbeddingClient:
 
     def __init__(self) -> None:
         logger.info(f"Loading embedding model: {MODEL_NAME}")
-        self.model = SentenceTransformer(MODEL_NAME)
+        local_files_only = os.getenv("HF_HUB_OFFLINE") == "1"
+        self.model = SentenceTransformer(MODEL_NAME, local_files_only=local_files_only)
         self.model_name = MODEL_NAME
         self.dimensions = 384
         logger.info(f"Embedding model loaded: {MODEL_NAME} ({self.dimensions}d)")
+
+    def is_ready(self) -> bool:
+        """Check if the embedding model is loaded and ready to use."""
+        return self.model is not None
+
+    def get_model_info(self) -> dict:
+        """Get current embedding model information."""
+        if not self.is_ready():
+            return {"status": "not_loaded"}
+        return {
+            "model_name": self.model_name,
+            "dimensions": self.dimensions,
+            "status": "loaded",
+        }
 
     def encode(self, text: str) -> list[float]:
         """Encode a single text into a 384-dimensional embedding vector."""

--- a/services/analyzer/src/main.py
+++ b/services/analyzer/src/main.py
@@ -1,9 +1,12 @@
+import asyncio
+from collections.abc import Callable, Mapping
 from contextlib import asynccontextmanager
 import logging
 import os
 import secrets
+from typing import Any
 
-from fastapi import FastAPI, Request
+from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import JSONResponse, Response
 from opentelemetry import (
     metrics as otel_metrics,
@@ -21,7 +24,7 @@ from opentelemetry.sdk.trace.export import BatchSpanProcessor
 from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
 from prometheus_client import CONTENT_TYPE_LATEST, REGISTRY, generate_latest
 
-from src.dependencies import get_sentiment_client, get_topic_client
+from src.dependencies import get_embedding_client, get_sentiment_client, get_topic_client
 from src.logger import setup_logging
 from src.routers.v1 import v1_router
 
@@ -29,6 +32,7 @@ setup_logging()
 logger = logging.getLogger(__name__)
 
 _service_resource = Resource({"service.name": "lotus-analyzer"})
+_MODEL_READY_TIMEOUT_SECONDS = 5.0
 
 
 def _init_tracer() -> None:
@@ -49,17 +53,27 @@ def _init_meter() -> None:
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     # Startup
+    app.state.models_ready = asyncio.Event()
+    app.state.model_load_status = {"status": "loading", "models": []}
     logger.info("Loading ML models...")
     try:
-        topic_client = get_topic_client()
-        topic_client.load_model()
-        logger.info("Topic model loaded successfully")
-
-        sentiment_client = get_sentiment_client()
-        sentiment_client.load_model()
-        logger.info("Sentiment model loaded successfully")
+        await asyncio.gather(
+            _load_startup_model("topic", lambda: get_topic_client().load_model()),
+            _load_startup_model("sentiment", lambda: get_sentiment_client().load_model()),
+            _load_startup_model("embedding", get_embedding_client),
+        )
+        app.state.model_load_status = {
+            "status": "loaded",
+            "models": _get_model_readiness(),
+        }
+        app.state.models_ready.set()
         logger.info("All ML models loaded successfully")
     except Exception as e:
+        app.state.model_load_status = {
+            "status": "failed",
+            "error": f"{type(e).__name__}: {e}",
+            "models": _get_model_readiness(),
+        }
         logger.error(f"Failed to load ML models: {type(e).__name__}: {e}", exc_info=True)
         logger.error("Application will start but ML endpoints may fail")
         # Re-raise to prevent app from starting if models are critical
@@ -81,6 +95,8 @@ _init_meter()
 set_global_textmap(CompositePropagator([TraceContextTextMapPropagator()]))
 
 app = FastAPI(lifespan=lifespan)
+app.state.models_ready = asyncio.Event()
+app.state.model_load_status = {"status": "not_started", "models": []}
 FastAPIInstrumentor.instrument_app(app)
 
 _ANALYZER_API_KEY = os.getenv("ANALYZER_API_KEY", "")
@@ -121,12 +137,67 @@ async def root():
 
 
 @app.get("/health")
-async def health():
-    logger.info("Log test")
-    return {"status": "healthy"}
+async def health(request: Request):
+    try:
+        await _wait_for_models_ready(request.app)
+    except TimeoutError:
+        raise HTTPException(
+            status_code=503,
+            detail={
+                "status": "unhealthy",
+                "service": "analyzer",
+                "models": request.app.state.model_load_status,
+            },
+        ) from None
+
+    return {
+        "status": "healthy",
+        "service": "analyzer",
+        "models": request.app.state.model_load_status["models"],
+    }
 
 
 @app.exception_handler(404)
 async def custom_404_handler(request: Request, exc):
     detail = getattr(exc, "detail", "this doesn't exist hoe")
     return JSONResponse(status_code=404, content={"detail": detail})
+
+
+async def _wait_for_models_ready(app: FastAPI) -> None:
+    await asyncio.wait_for(
+        app.state.models_ready.wait(),
+        timeout=_MODEL_READY_TIMEOUT_SECONDS,
+    )
+
+
+async def _load_startup_model(name: str, load: Callable[[], Any]) -> None:
+    logger.info(f"Loading {name} model...")
+    await asyncio.to_thread(load)
+    logger.info(f"{name.capitalize()} model loaded successfully")
+
+
+def _get_model_readiness() -> list[dict[str, Any]]:
+    checks = [
+        ("topic", get_topic_client),
+        ("sentiment", get_sentiment_client),
+        ("embedding", get_embedding_client),
+    ]
+    readiness = []
+    for name, client_factory in checks:
+        try:
+            client = client_factory()
+            ready = client.is_ready()
+            info = client.get_model_info() if hasattr(client, "get_model_info") else {}
+            if not isinstance(info, Mapping):
+                info = {}
+        except Exception as e:
+            readiness.append(
+                {
+                    "name": name,
+                    "ready": False,
+                    "error": f"{type(e).__name__}: {e}",
+                }
+            )
+            continue
+        readiness.append({"name": name, "ready": ready, **info})
+    return readiness

--- a/services/analyzer/tests/conftest.py
+++ b/services/analyzer/tests/conftest.py
@@ -182,6 +182,7 @@ def postgres_container():
                 line
                 for line in _BOOTSTRAP_SQL.read_text().splitlines()
                 if not line.strip().upper().startswith("CREATE DATABASE")
+                and not line.strip().startswith("\\")
             )
             cur.execute(bootstrap_sql)
             cur.execute(_SOURCE_SCHEMA_SQL.read_text())

--- a/services/analyzer/tests/unit/test_embedding_client.py
+++ b/services/analyzer/tests/unit/test_embedding_client.py
@@ -10,10 +10,27 @@ def test_embedding_client_initializes_model(monkeypatch):
 
     client = embedding_module.EmbeddingClient()
 
-    constructor.assert_called_once_with(embedding_module.MODEL_NAME)
+    constructor.assert_called_once_with(embedding_module.MODEL_NAME, local_files_only=False)
     assert client.model is transformer
     assert client.model_name == embedding_module.MODEL_NAME
     assert client.dimensions == 384
+    assert client.is_ready() is True
+    assert client.get_model_info() == {
+        "model_name": embedding_module.MODEL_NAME,
+        "dimensions": 384,
+        "status": "loaded",
+    }
+
+
+def test_embedding_client_uses_local_files_when_hf_offline(monkeypatch):
+    transformer = Mock()
+    constructor = Mock(return_value=transformer)
+    monkeypatch.setattr(embedding_module, "SentenceTransformer", constructor)
+    monkeypatch.setenv("HF_HUB_OFFLINE", "1")
+
+    embedding_module.EmbeddingClient()
+
+    constructor.assert_called_once_with(embedding_module.MODEL_NAME, local_files_only=True)
 
 
 def test_embedding_client_encode_returns_list(monkeypatch):

--- a/services/analyzer/tests/unit/test_main.py
+++ b/services/analyzer/tests/unit/test_main.py
@@ -1,3 +1,4 @@
+from typing import cast
 from unittest.mock import AsyncMock, Mock
 
 from fastapi import HTTPException
@@ -82,7 +83,8 @@ async def test_health_waits_for_models_to_be_ready(monkeypatch):
         await main_module.health(request)
 
     assert exc_info.value.status_code == 503
-    assert exc_info.value.detail["models"]["status"] == "loading"
+    detail = cast("dict[str, dict[str, object]]", exc_info.value.detail)
+    assert detail["models"]["status"] == "loading"
     wait_for_ready.assert_awaited_once_with(request.app)
 
 

--- a/services/analyzer/tests/unit/test_main.py
+++ b/services/analyzer/tests/unit/test_main.py
@@ -52,9 +52,38 @@ async def test_auth_middleware_allows_valid_token():
 
 
 @pytest.mark.anyio
-async def test_root_and_health_endpoints():
+async def test_root_and_health_endpoints(monkeypatch):
     assert await main_module.root() == {"message": "Hello World"}
-    assert await main_module.health() == {"status": "healthy"}
+
+    request = Mock()
+    request.app.state.model_load_status = {
+        "status": "loaded",
+        "models": [{"name": "topic", "ready": True}],
+    }
+    wait_for_ready = AsyncMock(return_value=None)
+    monkeypatch.setattr(main_module, "_wait_for_models_ready", wait_for_ready)
+
+    assert await main_module.health(request) == {
+        "status": "healthy",
+        "service": "analyzer",
+        "models": [{"name": "topic", "ready": True}],
+    }
+    wait_for_ready.assert_awaited_once_with(request.app)
+
+
+@pytest.mark.anyio
+async def test_health_waits_for_models_to_be_ready(monkeypatch):
+    request = Mock()
+    request.app.state.model_load_status = {"status": "loading", "models": []}
+    wait_for_ready = AsyncMock(side_effect=TimeoutError)
+    monkeypatch.setattr(main_module, "_wait_for_models_ready", wait_for_ready)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await main_module.health(request)
+
+    assert exc_info.value.status_code == 503
+    assert exc_info.value.detail["models"]["status"] == "loading"
+    wait_for_ready.assert_awaited_once_with(request.app)
 
 
 @pytest.mark.anyio
@@ -79,21 +108,45 @@ async def test_custom_404_handler_uses_default_detail():
 async def test_lifespan_loads_models(monkeypatch):
     topic_client = Mock()
     sentiment_client = Mock()
+    embedding_client = Mock()
+    topic_client.is_ready.return_value = True
+    sentiment_client.is_ready.return_value = True
+    embedding_client.is_ready.return_value = True
+    topic_client.get_model_info.return_value = {"status": "loaded"}
+    sentiment_client.get_model_info.return_value = {"status": "loaded"}
+    embedding_client.get_model_info.return_value = {"status": "loaded"}
     monkeypatch.setattr(main_module, "get_topic_client", Mock(return_value=topic_client))
     monkeypatch.setattr(main_module, "get_sentiment_client", Mock(return_value=sentiment_client))
+    monkeypatch.setattr(main_module, "get_embedding_client", Mock(return_value=embedding_client))
+
+    async def load_model(_name, load):
+        load()
+
+    monkeypatch.setattr(main_module, "_load_startup_model", load_model)
 
     async with main_module.lifespan(main_module.app):
         pass
 
     topic_client.load_model.assert_called_once()
     sentiment_client.load_model.assert_called_once()
+    main_module.get_embedding_client.assert_called()
+    assert main_module.app.state.models_ready.is_set()
 
 
 @pytest.mark.anyio
 async def test_lifespan_reraises_load_failures(monkeypatch):
     topic_client = Mock()
     topic_client.load_model.side_effect = RuntimeError("boom")
+    sentiment_client = Mock()
+    embedding_client = Mock()
     monkeypatch.setattr(main_module, "get_topic_client", Mock(return_value=topic_client))
+    monkeypatch.setattr(main_module, "get_sentiment_client", Mock(return_value=sentiment_client))
+    monkeypatch.setattr(main_module, "get_embedding_client", Mock(return_value=embedding_client))
+
+    async def load_model(_name, load):
+        load()
+
+    monkeypatch.setattr(main_module, "_load_startup_model", load_model)
 
     with pytest.raises(RuntimeError, match="boom"):
         async with main_module.lifespan(main_module.app):

--- a/services/analyzer/uv.lock
+++ b/services/analyzer/uv.lock
@@ -94,6 +94,8 @@ dependencies = [
     { name = "pydantic-settings" },
     { name = "sentence-transformers" },
     { name = "sqlalchemy" },
+    { name = "torch", version = "2.12.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform == 'darwin'" },
+    { name = "torch", version = "2.12.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform != 'darwin'" },
 ]
 
 [package.dev-dependencies]
@@ -125,6 +127,7 @@ requires-dist = [
     { name = "pydantic-settings", specifier = ">=2.10.1" },
     { name = "sentence-transformers", specifier = ">=3.0.0" },
     { name = "sqlalchemy", specifier = ">=2.0.41" },
+    { name = "torch", specifier = ">=2.0.0", index = "https://download.pytorch.org/whl/cpu" },
 ]
 
 [package.metadata.requires-dev]
@@ -409,26 +412,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/82/27/092d311af22095d288f4db89fcaebadfb2f28944f3d790a4cf51fe5ddaeb/cryptography-45.0.6-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:5b64e668fc3528e77efa51ca70fadcd6610e8ab231e3e06ae2bab3b31c2b8ed9", size = 4554815, upload-time = "2025-08-05T23:59:00.283Z" },
     { url = "https://files.pythonhosted.org/packages/7e/01/aa2f4940262d588a8fdf4edabe4cda45854d00ebc6eaac12568b3a491a16/cryptography-45.0.6-cp37-abi3-win32.whl", hash = "sha256:780c40fb751c7d2b0c6786ceee6b6f871e86e8718a8ff4bc35073ac353c7cd02", size = 2912147, upload-time = "2025-08-05T23:59:01.716Z" },
     { url = "https://files.pythonhosted.org/packages/0a/bc/16e0276078c2de3ceef6b5a34b965f4436215efac45313df90d55f0ba2d2/cryptography-45.0.6-cp37-abi3-win_amd64.whl", hash = "sha256:20d15aed3ee522faac1a39fbfdfee25d17b1284bafd808e1640a74846d7c4d1b", size = 3390459, upload-time = "2025-08-05T23:59:03.358Z" },
-]
-
-[[package]]
-name = "cuda-bindings"
-version = "12.9.4"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "cuda-pathfinder", marker = "sys_platform != 'darwin'" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/63/56/e465c31dc9111be3441a9ba7df1941fe98f4aa6e71e8788a3fb4534ce24d/cuda_bindings-12.9.4-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:32bdc5a76906be4c61eb98f546a6786c5773a881f3b166486449b5d141e4a39f", size = 11906628, upload-time = "2025-10-21T14:51:49.905Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/84/1e6be415e37478070aeeee5884c2022713c1ecc735e6d82d744de0252eee/cuda_bindings-12.9.4-cp313-cp313t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:56e0043c457a99ac473ddc926fe0dc4046694d99caef633e92601ab52cbe17eb", size = 11925991, upload-time = "2025-10-21T14:51:56.535Z" },
-]
-
-[[package]]
-name = "cuda-pathfinder"
-version = "1.4.3"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c0/59/911a1a597264f1fb7ac176995a0f0b6062e37f8c1b6e0f23071a76838507/cuda_pathfinder-1.4.3-py3-none-any.whl", hash = "sha256:4345d8ead1f701c4fb8a99be6bc1843a7348b6ba0ef3b031f5a2d66fb128ae4c", size = 47951, upload-time = "2026-03-16T21:31:25.526Z" },
 ]
 
 [[package]]
@@ -1477,140 +1460,6 @@ wheels = [
 ]
 
 [[package]]
-name = "nvidia-cublas-cu12"
-version = "12.8.4.1"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/dc/61/e24b560ab2e2eaeb3c839129175fb330dfcfc29e5203196e5541a4c44682/nvidia_cublas_cu12-12.8.4.1-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:8ac4e771d5a348c551b2a426eda6193c19aa630236b418086020df5ba9667142", size = 594346921, upload-time = "2025-03-07T01:44:31.254Z" },
-]
-
-[[package]]
-name = "nvidia-cuda-cupti-cu12"
-version = "12.8.90"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f8/02/2adcaa145158bf1a8295d83591d22e4103dbfd821bcaf6f3f53151ca4ffa/nvidia_cuda_cupti_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ea0cb07ebda26bb9b29ba82cda34849e73c166c18162d3913575b0c9db9a6182", size = 10248621, upload-time = "2025-03-07T01:40:21.213Z" },
-]
-
-[[package]]
-name = "nvidia-cuda-nvrtc-cu12"
-version = "12.8.93"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/05/6b/32f747947df2da6994e999492ab306a903659555dddc0fbdeb9d71f75e52/nvidia_cuda_nvrtc_cu12-12.8.93-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:a7756528852ef889772a84c6cd89d41dfa74667e24cca16bb31f8f061e3e9994", size = 88040029, upload-time = "2025-03-07T01:42:13.562Z" },
-]
-
-[[package]]
-name = "nvidia-cuda-runtime-cu12"
-version = "12.8.90"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/0d/9b/a997b638fcd068ad6e4d53b8551a7d30fe8b404d6f1804abf1df69838932/nvidia_cuda_runtime_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:adade8dcbd0edf427b7204d480d6066d33902cab2a4707dcfc48a2d0fd44ab90", size = 954765, upload-time = "2025-03-07T01:40:01.615Z" },
-]
-
-[[package]]
-name = "nvidia-cudnn-cu12"
-version = "9.10.2.21"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "nvidia-cublas-cu12", marker = "sys_platform != 'darwin'" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ba/51/e123d997aa098c61d029f76663dedbfb9bc8dcf8c60cbd6adbe42f76d049/nvidia_cudnn_cu12-9.10.2.21-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:949452be657fa16687d0930933f032835951ef0892b37d2d53824d1a84dc97a8", size = 706758467, upload-time = "2025-06-06T21:54:08.597Z" },
-]
-
-[[package]]
-name = "nvidia-cufft-cu12"
-version = "11.3.3.83"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform != 'darwin'" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1f/13/ee4e00f30e676b66ae65b4f08cb5bcbb8392c03f54f2d5413ea99a5d1c80/nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4d2dd21ec0b88cf61b62e6b43564355e5222e4a3fb394cac0db101f2dd0d4f74", size = 193118695, upload-time = "2025-03-07T01:45:27.821Z" },
-]
-
-[[package]]
-name = "nvidia-cufile-cu12"
-version = "1.13.1.3"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/bb/fe/1bcba1dfbfb8d01be8d93f07bfc502c93fa23afa6fd5ab3fc7c1df71038a/nvidia_cufile_cu12-1.13.1.3-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1d069003be650e131b21c932ec3d8969c1715379251f8d23a1860554b1cb24fc", size = 1197834, upload-time = "2025-03-07T01:45:50.723Z" },
-]
-
-[[package]]
-name = "nvidia-curand-cu12"
-version = "10.3.9.90"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/fb/aa/6584b56dc84ebe9cf93226a5cde4d99080c8e90ab40f0c27bda7a0f29aa1/nvidia_curand_cu12-10.3.9.90-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:b32331d4f4df5d6eefa0554c565b626c7216f87a06a4f56fab27c3b68a830ec9", size = 63619976, upload-time = "2025-03-07T01:46:23.323Z" },
-]
-
-[[package]]
-name = "nvidia-cusolver-cu12"
-version = "11.7.3.90"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "nvidia-cublas-cu12", marker = "sys_platform != 'darwin'" },
-    { name = "nvidia-cusparse-cu12", marker = "sys_platform != 'darwin'" },
-    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform != 'darwin'" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/85/48/9a13d2975803e8cf2777d5ed57b87a0b6ca2cc795f9a4f59796a910bfb80/nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:4376c11ad263152bd50ea295c05370360776f8c3427b30991df774f9fb26c450", size = 267506905, upload-time = "2025-03-07T01:47:16.273Z" },
-]
-
-[[package]]
-name = "nvidia-cusparse-cu12"
-version = "12.5.8.93"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform != 'darwin'" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c2/f5/e1854cb2f2bcd4280c44736c93550cc300ff4b8c95ebe370d0aa7d2b473d/nvidia_cusparse_cu12-12.5.8.93-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1ec05d76bbbd8b61b06a80e1eaf8cf4959c3d4ce8e711b65ebd0443bb0ebb13b", size = 288216466, upload-time = "2025-03-07T01:48:13.779Z" },
-]
-
-[[package]]
-name = "nvidia-cusparselt-cu12"
-version = "0.7.1"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/56/79/12978b96bd44274fe38b5dde5cfb660b1d114f70a65ef962bcbbed99b549/nvidia_cusparselt_cu12-0.7.1-py3-none-manylinux2014_x86_64.whl", hash = "sha256:f1bb701d6b930d5a7cea44c19ceb973311500847f81b634d802b7b539dc55623", size = 287193691, upload-time = "2025-02-26T00:15:44.104Z" },
-]
-
-[[package]]
-name = "nvidia-nccl-cu12"
-version = "2.27.5"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/6e/89/f7a07dc961b60645dbbf42e80f2bc85ade7feb9a491b11a1e973aa00071f/nvidia_nccl_cu12-2.27.5-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ad730cf15cb5d25fe849c6e6ca9eb5b76db16a80f13f425ac68d8e2e55624457", size = 322348229, upload-time = "2025-06-26T04:11:28.385Z" },
-]
-
-[[package]]
-name = "nvidia-nvjitlink-cu12"
-version = "12.8.93"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f6/74/86a07f1d0f42998ca31312f998bd3b9a7eff7f52378f4f270c8679c77fb9/nvidia_nvjitlink_cu12-12.8.93-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:81ff63371a7ebd6e6451970684f916be2eab07321b73c9d244dc2b4da7f73b88", size = 39254836, upload-time = "2025-03-07T01:49:55.661Z" },
-]
-
-[[package]]
-name = "nvidia-nvshmem-cu12"
-version = "3.4.5"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b5/09/6ea3ea725f82e1e76684f0708bbedd871fc96da89945adeba65c3835a64c/nvidia_nvshmem_cu12-3.4.5-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:042f2500f24c021db8a06c5eec2539027d57460e1c1a762055a6554f72c369bd", size = 139103095, upload-time = "2025-09-06T00:32:31.266Z" },
-]
-
-[[package]]
-name = "nvidia-nvtx-cu12"
-version = "12.8.90"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a2/eb/86626c1bbc2edb86323022371c39aa48df6fd8b0a1647bc274577f72e90b/nvidia_nvtx_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5b17e2001cc0d751a5bc2c6ec6d26ad95913324a4adb86788c944f8ce9ba441f", size = 89954, upload-time = "2025-03-07T01:42:44.131Z" },
-]
-
-[[package]]
 name = "openai"
 version = "1.108.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2552,7 +2401,8 @@ dependencies = [
     { name = "numpy" },
     { name = "scikit-learn" },
     { name = "scipy" },
-    { name = "torch" },
+    { name = "torch", version = "2.12.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform == 'darwin'" },
+    { name = "torch", version = "2.12.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform != 'darwin'" },
     { name = "tqdm" },
     { name = "transformers" },
     { name = "typing-extensions" },
@@ -2577,11 +2427,11 @@ wheels = [
 
 [[package]]
 name = "setuptools"
-version = "82.0.1"
+version = "81.0.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4f/db/cfac1baf10650ab4d1c111714410d2fbb77ac5a616db26775db562c8fab2/setuptools-82.0.1.tar.gz", hash = "sha256:7d872682c5d01cfde07da7bccc7b65469d3dca203318515ada1de5eda35efbf9", size = 1152316, upload-time = "2026-03-09T12:47:17.221Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0d/1c/73e719955c59b8e424d015ab450f51c0af856ae46ea2da83eba51cc88de1/setuptools-81.0.0.tar.gz", hash = "sha256:487b53915f52501f0a79ccfd0c02c165ffe06631443a886740b91af4b7a5845a", size = 1198299, upload-time = "2026-02-06T21:10:39.601Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9d/76/f789f7a86709c6b087c5a2f52f911838cad707cc613162401badc665acfe/setuptools-82.0.1-py3-none-any.whl", hash = "sha256:a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb", size = 1006223, upload-time = "2026-03-09T12:47:15.026Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/e3/c164c88b2e5ce7b24d667b9bd83589cf4f3520d97cad01534cd3c4f55fdb/setuptools-81.0.0-py3-none-any.whl", hash = "sha256:fdd925d5c5d9f62e4b74b30d6dd7828ce236fd6ed998a08d81de62ce5a6310d6", size = 1062021, upload-time = "2026-02-06T21:10:37.175Z" },
 ]
 
 [[package]]
@@ -2766,46 +2616,51 @@ wheels = [
 
 [[package]]
 name = "torch"
-version = "2.10.0"
-source = { registry = "https://pypi.org/simple" }
+version = "2.12.0"
+source = { registry = "https://download.pytorch.org/whl/cpu" }
+resolution-markers = [
+    "sys_platform == 'darwin'",
+]
 dependencies = [
-    { name = "cuda-bindings", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "filelock" },
-    { name = "fsspec" },
-    { name = "jinja2" },
-    { name = "networkx" },
-    { name = "nvidia-cublas-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cuda-cupti-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cuda-nvrtc-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cuda-runtime-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cudnn-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cufft-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cufile-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-curand-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cusolver-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cusparse-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cusparselt-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-nccl-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-nvjitlink-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-nvshmem-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-nvtx-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "setuptools" },
-    { name = "sympy" },
-    { name = "triton", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "typing-extensions" },
+    { name = "filelock", marker = "sys_platform == 'darwin'" },
+    { name = "fsspec", marker = "sys_platform == 'darwin'" },
+    { name = "jinja2", marker = "sys_platform == 'darwin'" },
+    { name = "networkx", marker = "sys_platform == 'darwin'" },
+    { name = "setuptools", marker = "sys_platform == 'darwin'" },
+    { name = "sympy", marker = "sys_platform == 'darwin'" },
+    { name = "typing-extensions", marker = "sys_platform == 'darwin'" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ec/23/2c9fe0c9c27f7f6cb865abcea8a4568f29f00acaeadfc6a37f6801f84cb4/torch-2.10.0-2-cp313-none-macosx_11_0_arm64.whl", hash = "sha256:e521c9f030a3774ed770a9c011751fb47c4d12029a3d6522116e48431f2ff89e", size = 79498254, upload-time = "2026-02-10T21:44:44.095Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/c6/4dfe238342ffdcec5aef1c96c457548762d33c40b45a1ab7033bb26d2ff2/torch-2.10.0-3-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:80b1b5bfe38eb0e9f5ff09f206dcac0a87aadd084230d4a36eea5ec5232c115b", size = 915627275, upload-time = "2026-03-11T14:16:11.325Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/f0/72bf18847f58f877a6a8acf60614b14935e2f156d942483af1ffc081aea0/torch-2.10.0-3-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:46b3574d93a2a8134b3f5475cfb98e2eb46771794c57015f6ad1fb795ec25e49", size = 915523474, upload-time = "2026-03-11T14:17:44.422Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/6f/f2e91e34e3fcba2e3fc8d8f74e7d6c22e74e480bbd1db7bc8900fdf3e95c/torch-2.10.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:5c4d217b14741e40776dd7074d9006fd28b8a97ef5654db959d8635b2fe5f29b", size = 146004247, upload-time = "2026-01-21T16:24:29.335Z" },
-    { url = "https://files.pythonhosted.org/packages/98/fb/5160261aeb5e1ee12ee95fe599d0541f7c976c3701d607d8fc29e623229f/torch-2.10.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:6b71486353fce0f9714ca0c9ef1c850a2ae766b409808acd58e9678a3edb7738", size = 915716445, upload-time = "2026-01-21T16:22:45.353Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/16/502fb1b41e6d868e8deb5b0e3ae926bbb36dab8ceb0d1b769b266ad7b0c3/torch-2.10.0-cp313-cp313-win_amd64.whl", hash = "sha256:c2ee399c644dc92ef7bc0d4f7e74b5360c37cdbe7c5ba11318dda49ffac2bc57", size = 113757050, upload-time = "2026-01-21T16:24:19.204Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/0b/39929b148f4824bc3ad6f9f72a29d4ad865bcf7ebfc2fa67584773e083d2/torch-2.10.0-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:3202429f58309b9fa96a614885eace4b7995729f44beb54d3e4a47773649d382", size = 79851305, upload-time = "2026-01-21T16:24:09.209Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/14/21fbce63bc452381ba5f74a2c0a959fdf5ad5803ccc0c654e752e0dbe91a/torch-2.10.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:aae1b29cd68e50a9397f5ee897b9c24742e9e306f88a807a27d617f07adb3bd8", size = 146005472, upload-time = "2026-01-21T16:22:29.022Z" },
-    { url = "https://files.pythonhosted.org/packages/54/fd/b207d1c525cb570ef47f3e9f836b154685011fce11a2f444ba8a4084d042/torch-2.10.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:6021db85958db2f07ec94e1bc77212721ba4920c12a18dc552d2ae36a3eb163f", size = 915612644, upload-time = "2026-01-21T16:21:47.019Z" },
-    { url = "https://files.pythonhosted.org/packages/36/53/0197f868c75f1050b199fe58f9bf3bf3aecac9b4e85cc9c964383d745403/torch-2.10.0-cp313-cp313t-win_amd64.whl", hash = "sha256:ff43db38af76fda183156153983c9a096fc4c78d0cd1e07b14a2314c7f01c2c8", size = 113997015, upload-time = "2026-01-21T16:23:00.767Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/13/e76b4d9c160e89fff48bf16b449ea324bda84745d2ab30294c37c2434c0d/torch-2.10.0-cp313-none-macosx_11_0_arm64.whl", hash = "sha256:cdf2a523d699b70d613243211ecaac14fe9c5df8a0b0a9c02add60fb2a413e0f", size = 79498248, upload-time = "2026-01-21T16:23:09.315Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:90dd587a5f61bfe1307148b581e2084fc5bc4a06e2b90a20e9a36b81087ff16b", upload-time = "2026-05-12T16:20:17Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.0-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:10ee1448a9f304d3b987eb4656f664ba6e4d7b410ca7a5a7c642199777a2cf88", upload-time = "2026-05-12T16:20:21Z" },
+]
+
+[[package]]
+name = "torch"
+version = "2.12.0+cpu"
+source = { registry = "https://download.pytorch.org/whl/cpu" }
+resolution-markers = [
+    "sys_platform != 'darwin'",
+]
+dependencies = [
+    { name = "filelock", marker = "sys_platform != 'darwin'" },
+    { name = "fsspec", marker = "sys_platform != 'darwin'" },
+    { name = "jinja2", marker = "sys_platform != 'darwin'" },
+    { name = "networkx", marker = "sys_platform != 'darwin'" },
+    { name = "setuptools", marker = "sys_platform != 'darwin'" },
+    { name = "sympy", marker = "sys_platform != 'darwin'" },
+    { name = "typing-extensions", marker = "sys_platform != 'darwin'" },
+]
+wheels = [
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.0%2Bcpu-cp313-cp313-linux_s390x.whl", hash = "sha256:5e0da19e1c3bfdc9b92638c552579eac678354485d61fc8921b0461fd6c40449", upload-time = "2026-05-12T23:17:05Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.0%2Bcpu-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:68b7ddd4db4603a03e106e74c7098c8d8c8943d33c1e5ada009ca4cd885759c3", upload-time = "2026-05-12T23:17:12Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.0%2Bcpu-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:ada78018bdfa30d1c766596cd32d910dbf5b03424cd859231b6d2a00533de922", upload-time = "2026-05-12T23:17:20Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.0%2Bcpu-cp313-cp313-win_amd64.whl", hash = "sha256:59bc266826e683899d49ee0af9829f3eafd0a16e15b5db9dc591c8d955003b66", upload-time = "2026-05-12T23:17:27Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.0%2Bcpu-cp313-cp313-win_arm64.whl", hash = "sha256:97a5160abf3ca9d59a2cd7b4b4de89d9dfe290d36a1ac720262a55fbcee10b6c", upload-time = "2026-05-12T23:17:31Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.0%2Bcpu-cp313-cp313t-linux_s390x.whl", hash = "sha256:32b9b7a0974cd6149cb98def0a28a49d92d7c14a384273d5539da9624239e950", upload-time = "2026-05-12T23:17:36Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.0%2Bcpu-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:93ed8dc52c113580daf6124982b3232629045dccc5cd83a8f5ed478f7bac7340", upload-time = "2026-05-12T23:17:43Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.0%2Bcpu-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:6a1c86abd4ed15a0736cf2663ad69642ae5d1288c99e30346070e6241018a0a9", upload-time = "2026-05-12T23:17:54Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.0%2Bcpu-cp313-cp313t-win_amd64.whl", hash = "sha256:768dce4b7b3353795f667d1cb0dd7dfba06f570cd39539576097335e05bb71fe", upload-time = "2026-05-12T23:18:02Z" },
 ]
 
 [[package]]
@@ -2866,15 +2721,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/fc/1a/70e830d53ecc96ce69cfa8de38f163712d2b43ac52fbd743f39f56025c31/transformers-5.3.0.tar.gz", hash = "sha256:009555b364029da9e2946d41f1c5de9f15e6b1df46b189b7293f33a161b9c557", size = 8830831, upload-time = "2026-03-04T17:41:46.119Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b8/88/ae8320064e32679a5429a2c9ebbc05c2bf32cefb6e076f9b07f6d685a9b4/transformers-5.3.0-py3-none-any.whl", hash = "sha256:50ac8c89c3c7033444fb3f9f53138096b997ebb70d4b5e50a2e810bf12d3d29a", size = 10661827, upload-time = "2026-03-04T17:41:42.722Z" },
-]
-
-[[package]]
-name = "triton"
-version = "3.6.0"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f9/0b/37d991d8c130ce81a8728ae3c25b6e60935838e9be1b58791f5997b24a54/triton-3.6.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:10c7f76c6e72d2ef08df639e3d0d30729112f47a56b0c81672edc05ee5116ac9", size = 188289450, upload-time = "2026-01-20T16:00:49.136Z" },
-    { url = "https://files.pythonhosted.org/packages/35/f8/9c66bfc55361ec6d0e4040a0337fb5924ceb23de4648b8a81ae9d33b2b38/triton-3.6.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d002e07d7180fd65e622134fbd980c9a3d4211fb85224b56a0a0efbd422ab72f", size = 188400296, upload-time = "2026-01-20T16:00:56.042Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

Bake the analyzer embedding model into the Docker image and make startup readiness wait for analyzer models to load. This also switches analyzer torch resolution to CPU-only wheels to avoid shipping CUDA dependencies.

### Added

- Startup loading for the embedding client
- Runtime offline mode for baked Hugging Face assets

### Updated

- Analyzer model startup now loads clients concurrently
- Analyzer dependencies now use CPU-only torch