### PR TITLE
chore: standardize agent skill and instruction files

### DIFF
--- a/.agents/skills/add-backend-endpoint/SKILL.md
+++ b/.agents/skills/add-backend-endpoint/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: add-backend-endpoint
-description: Step-by-step workflow for adding a new gRPC/HTTP endpoint to the Go backend service, including proto definitions, SQL queries, handler implementation, gateway registration, and tests.
+description: Manual skill, do not invoke automatically. Use only when user explicitly runs add-backend-endpoint by name. Step-by-step workflow for adding a new gRPC/HTTP endpoint to the Go backend service, including proto definitions, SQL queries, handler implementation, gateway registration, and tests.
+disable-model-invocation: true
+user-invocable: true
 ---
 
 ## When to use this skill
@@ -44,16 +46,16 @@ Run code generation:
 make sqlc-generate
 ```
 
-This regenerates `services/backend/internal/db/` including `querier.go`, `models.go`, and query implementation files. **Do not edit files in `internal/db/` directly.**
+This regenerates `services/backend/internal/db/` including `querier.go`, `models.go`, and query implementation files. Do not edit files in `internal/db/` directly.
 
 ### Step 2: Define proto messages and service RPCs
 
-**For an existing domain** (e.g., journal), edit the existing proto files:
+For an existing domain (e.g., journal), edit the existing proto files:
 
 - Message types: `services/backend/proto/{domain}/{domain}.proto`
 - Service RPCs: `services/backend/proto/{domain}/{domain}_service.proto`
 
-**For a new domain**, create both files under `services/backend/proto/{new_domain}/`.
+For a new domain, create both files under `services/backend/proto/{new_domain}/`.
 
 Message definition example (`{domain}.proto`):
 
@@ -112,13 +114,13 @@ Run code generation:
 make buf-generate
 ```
 
-This regenerates `services/backend/internal/pb/proto/{domain}/` with `*.pb.go`, `*_grpc.pb.go`, and `*.pb.gw.go` files. **Do not edit files in `internal/pb/` directly.**
+This regenerates `services/backend/internal/pb/proto/{domain}/` with `*.pb.go`, `*_grpc.pb.go`, and `*.pb.gw.go` files. Do not edit files in `internal/pb/` directly.
 
 ### Step 3: Implement the gRPC handler
 
-**For an existing domain**, add the method to the existing server struct in `services/backend/internal/grpc/{domain}_service.go`.
+For an existing domain, add the method to the existing server struct in `services/backend/internal/grpc/{domain}_service.go`.
 
-**For a new domain**, create `services/backend/internal/grpc/{new_domain}_service.go`:
+For a new domain, create `services/backend/internal/grpc/{new_domain}_service.go`:
 
 ```go
 package grpc
@@ -151,9 +153,9 @@ func (s *{Domain}Server) GetWidget(ctx context.Context, req *pb.GetWidgetRequest
 
 Key conventions:
 
-- Service structs are **empty** (only embed `Unimplemented*Server`). There are no `DB`, `Logger`, or other fields -- all dependencies come from context via the `internal/inject` package.
+- Service structs are empty (only embed `Unimplemented*Server`). There are no `DB`, `Logger`, or other fields -- all dependencies come from context via the `internal/inject` package.
 - A gRPC unary interceptor in `main.go` populates every request context with `db.Querier`, `*slog.Logger`, `inject.HTTPDoer`, and the analyzer URL. Service methods extract what they need via `inject.DBFrom(ctx)`, `inject.LoggerFrom(ctx)`, etc.
-- **Extract deps after input validation.** This way, tests for validation failures (bad UUIDs, missing fields) can use a bare `context.Background()` without setting up any dependencies.
+- Extract deps after input validation. This way, tests for validation failures (bad UUIDs, missing fields) can use a bare `context.Background()` without setting up any dependencies.
 - Use `log/slog` for structured logging.
 - Return gRPC status errors: `status.Errorf(codes.NotFound, "widget not found")`.
 - Log errors with context before returning them.
@@ -165,7 +167,7 @@ Skip this step if adding an RPC to an existing service.
 
 Both gRPC and gateway registration live in `services/backend/internal/grpc/server.go`. Add the new service to both functions so that `main.go` does not need any changes.
 
-**In `RegisterServices`**, add the gRPC registration:
+In `RegisterServices`, add the gRPC registration:
 
 ```go
 import pb_{domain} "github.com/jyablonski/lotus/internal/pb/proto/{domain}"
@@ -174,7 +176,7 @@ import pb_{domain} "github.com/jyablonski/lotus/internal/pb/proto/{domain}"
 pb_{domain}.Register{Domain}ServiceServer(s, &{Domain}Server{})
 ```
 
-**In `RegisterGateway`**, add the gateway handler registration:
+In `RegisterGateway`, add the gateway handler registration:
 
 ```go
 // Add to the slice inside RegisterGateway():
@@ -191,7 +193,7 @@ If the `Querier` interface changed (new SQL queries were added):
 make moq-generate
 ```
 
-This regenerates `services/backend/internal/mocks/querier_mock.go`. **Do not edit files in `internal/mocks/` directly.**
+This regenerates `services/backend/internal/mocks/querier_mock.go`. Do not edit files in `internal/mocks/` directly.
 
 ### Step 6: Write tests
 
@@ -260,20 +262,20 @@ func Test{Domain}Server_GetWidget_InvalidInput(t *testing.T) {
 
 Add integration tests in `services/backend/internal/grpc/{domain}_service_integration_test.go`. All integration tests use `package grpc_test` (same as unit tests) and share the helpers from `testhelpers_test.go`.
 
-**How the DB container works** (`testmain_test.go`):
+How the DB container works (`testmain_test.go`):
 
 `TestMain` calls `testinfra.Setup(ctx, "../sql/schema")`, which starts a single ephemeral `pgvector/pgvector:pg16` Postgres container, applies goose migrations, runs River migrations, starts Redis, and terminates everything after the package test run. This means:
 
 - No external postgres required — `make test-backend` is fully self-contained
 - Running tests never touches your local Tilt postgres
-- The container starts **once per `go test` invocation**, not once per test function
+- The container starts once per `go test` invocation, not once per test function
 
-**Per-test isolation: transaction rollback**
+Per-test isolation: transaction rollback
 Each `newTestCtx(t)` call begins a fresh pgx transaction from the package test pool. `db.New(tx)` is used because sqlc's `New()` accepts the `DBTX` interface, which both `pgx.Tx` and `*pgxpool.Pool` satisfy. `t.Cleanup` rolls back the transaction. Since the transaction is never committed, every write is discarded at cleanup.
 
 One implication: if two records are inserted in the same `newTestCtx` transaction within the same millisecond, `ORDER BY created_at DESC` is non-deterministic. Use a map-based assertion or insert records in separate `newTestCtx` calls if ordering matters.
 
-**Shared setup** (`testhelpers_test.go`):
+Shared setup (`testhelpers_test.go`):
 
 - `newTestCtx(t)` — begins a pgx transaction, registers `t.Cleanup` to roll back, injects `queries` into context, and returns `(ctx context.Context, queries *db.Queries)`.
 - `newDirectQueries(t)` — returns sqlc queries on the shared pool for tests that must observe rows committed outside the test transaction.
@@ -282,7 +284,7 @@ One implication: if two records are inserted in the same `newTestCtx` transactio
 - `testinfra.MockAnalyzerServer(t)` / `testinfra.FailingAnalyzerServer(t)` — httptest servers with `t.Cleanup(srv.Close)` registered automatically.
 - `createTestUser`, `createTestJournal`, `createTestGameBalance`, `createTestGameBet`, and `createTestCommunityUser` delegate to `internal/testfixtures`.
 
-**Fixture helpers** (`internal/testfixtures`):
+Fixture helpers (`internal/testfixtures`):
 
 Use `testfixtures.CreateWithDefaults` for supported setup records instead of hand-writing sqlc params:
 
@@ -369,7 +371,7 @@ Test patterns to cover:
 
 After adding a new endpoint, add a corresponding `.bru` request file to the Bruno collection so the team can test it from the Bruno GUI.
 
-**Backend requests** go in `bruno/backend/`. Create a new `.bru` file named after the endpoint (e.g., `get-widget.bru`):
+Backend requests go in `bruno/backend/`. Create a new `.bru` file named after the endpoint (e.g., `get-widget.bru`):
 
 ```bru
 meta {
@@ -432,11 +434,11 @@ Service files define sentinel errors (`var ErrXxx = errors.New("...")`) for doma
 
 ### When to use sentinels
 
-Use a sentinel for **validation and domain conditions** -- things the caller could branch on:
+Use a sentinel for validation and domain conditions -- things the caller could branch on:
 
 - `ErrInvalidUserID`, `ErrEmailRequired`, `ErrUserNotFound`, `ErrInvalidJournalID`, `ErrJournalNotFound`
 
-Do **not** use sentinels for **operational wrap errors** that just add context to an underlying cause. These stay as plain `fmt.Errorf`:
+Do not use sentinels for operational wrap errors that just add context to an underlying cause. These stay as plain `fmt.Errorf`:
 
 - `fmt.Errorf("failed to create journal: %w", err)` -- the caller checks the wrapped `err`, not the message prefix
 
@@ -449,13 +451,13 @@ Do **not** use sentinels for **operational wrap errors** that just add context t
 
 There are two patterns depending on how the error is returned:
 
-**`fmt.Errorf` wrapping** (non-gRPC returns): wrap with `%w` so `errors.Is()` works:
+`fmt.Errorf` wrapping (non-gRPC returns): wrap with `%w` so `errors.Is()` works:
 
 ```go
 return nil, fmt.Errorf("%w: %w", ErrInvalidUserID, err)
 ```
 
-**`status.Error` / `status.Errorf`** (gRPC returns): embed via `.Error()` since gRPC status errors don't support `errors.Is()` on the inner sentinel:
+`status.Error` / `status.Errorf` (gRPC returns): embed via `.Error()` since gRPC status errors don't support `errors.Is()` on the inner sentinel:
 
 ```go
 return nil, status.Error(codes.NotFound, ErrUserNotFound.Error())

--- a/.agents/skills/add-dagster-asset/SKILL.md
+++ b/.agents/skills/add-dagster-asset/SKILL.md
@@ -1,11 +1,8 @@
 ---
-name: dagster-asset
-description: >
-  Step-by-step workflow for adding new Dagster assets, resources, and jobs to the Lotus
-  data pipeline. Covers auto-discovery of assets, manual resource registration, job/schedule
-  definitions, dbt asset integration, and the SQL query pattern. Use this skill whenever
-  the user wants to add a new Dagster asset, resource, job, schedule, or asks how the
-  Dagster project's auto-import and resource registration works.
+name: add-dagster-asset
+description: Manual skill, do not invoke automatically. Use only when user explicitly runs add-dagster-asset by name. Step-by-step workflow for adding new Dagster assets, resources, and jobs to the Lotus data pipeline. Covers auto-discovery of assets, manual resource registration, job/schedule definitions, dbt asset integration, and the SQL query pattern. Use this skill whenever the user wants to add a new Dagster asset, resource, job, schedule, or asks how the Dagster project's auto-import and resource registration works.
+disable-model-invocation: true
+user-invocable: true
 ---
 
 # Dagster Asset Workflow
@@ -14,15 +11,15 @@ Source code: `services/dagster/src/dagster_project/` | Entry point: `definitions
 
 ## Auto-Discovery vs Manual Registration
 
-| Component     | Auto-discovered? | How to add                                         |
-| ------------- | ---------------- | -------------------------------------------------- |
-| Assets        | Yes              | Create file in `assets/`                           |
-| Jobs          | Yes              | Create file in `jobs/`                             |
-| Schedules     | Yes              | Define alongside the job                           |
-| Sensors       | Yes              | Create file in `sensors/`                          |
-| **Resources** | **No**           | Add to `RESOURCES` dict in `resources/__init__.py` |
+| Component | Auto-discovered? | How to add                                         |
+| --------- | ---------------- | -------------------------------------------------- |
+| Assets    | Yes              | Create file in `assets/`                           |
+| Jobs      | Yes              | Create file in `jobs/`                             |
+| Schedules | Yes              | Define alongside the job                           |
+| Sensors   | Yes              | Create file in `sensors/`                          |
+| Resources | No               | Add to `RESOURCES` dict in `resources/__init__.py` |
 
-Assets are found via `load_assets_from_package_module(assets)`. Jobs/schedules are found via `jobs/__init__.py` auto-importing all modules, then `_collect_from_package()` collecting top-level definitions. **Resources must be explicitly registered.**
+Assets are found via `load_assets_from_package_module(assets)`. Jobs/schedules are found via `jobs/__init__.py` auto-importing all modules, then `_collect_from_package()` collecting top-level definitions. Resources must be explicitly registered.
 
 ---
 
@@ -81,9 +78,9 @@ context.add_output_metadata({"num_rows": len(df)})
 
 ## Adding a New Resource
 
-Resources are **NOT auto-discovered**. Three steps required:
+Resources are NOT auto-discovered. Three steps required:
 
-**1. Create** `resources/my_resource.py`:
+1. Create `resources/my_resource.py`:
 
 ```python
 from dagster import ConfigurableResource, EnvVar
@@ -101,7 +98,7 @@ class MyResource(ConfigurableResource):
 my_resource = MyResource(api_key=EnvVar("MY_RESOURCE_API_KEY"), base_url=EnvVar("MY_RESOURCE_BASE_URL"))
 ```
 
-**2. Register** in `resources/__init__.py` -- key must match the parameter name assets use:
+2. Register in `resources/__init__.py` -- key must match the parameter name assets use:
 
 ```python
 from .my_resource import MyResource, my_resource
@@ -112,7 +109,7 @@ RESOURCES: dict = {
 }
 ```
 
-**3. Add env vars** to `docker/docker-compose-local.yaml` under the dagster service.
+3. Add env vars to `docker/docker-compose-local.yaml` under the dagster service.
 
 ---
 

--- a/.agents/skills/add-dbt-model/SKILL.md
+++ b/.agents/skills/add-dbt-model/SKILL.md
@@ -1,11 +1,8 @@
 ---
-name: dbt-model
-description: >
-  Step-by-step workflow for adding new dbt models to the Lotus analytics project.
-  Covers source definitions, the silver/gold medallion architecture (staging stg_,
-  core fct_/dim_, gold analytics), incremental materialization, tagging, primary key
-  tests, and dbt-utils tests. Use this skill whenever the user wants to add a new
-  dbt model, source, or test, or asks how the dbt layer structure works.
+name: add-dbt-model
+description: Manual skill, do not invoke automatically. Use only when user explicitly runs add-dbt-model by name. Step-by-step workflow for adding new dbt models to the Lotus analytics project. Covers source definitions, the silver/gold medallion architecture (staging stg_, core fct_/dim_, gold analytics), incremental materialization, tagging, primary key tests, and dbt-utils tests. Use this skill whenever the user wants to add a new dbt model, source, or test, or asks how the dbt layer structure works.
+disable-model-invocation: true
+user-invocable: true
 ---
 
 # dbt Model Workflow
@@ -27,7 +24,7 @@ Output schemas (`silver` or `gold`) are controlled by `dbt_project.yml` + `macro
 
 ## Step 1: Define the source
 
-**Location:** `models/sources/application_db/{table_name}.yml` -- one file per table, all use `schema: source` and `name: application_db`.
+Location: `models/sources/application_db/{table_name}.yml` -- one file per table, all use `schema: source` and `name: application_db`.
 
 ```yaml
 version: 2
@@ -48,7 +45,7 @@ sources:
 
 Light transforms: rename columns, cast types. Always incremental on `modified_at` with a default value of `1970-01-01` for the initial load.
 
-**SQL:** `models/silver/staging/stg_{table_name}.sql`
+SQL: `models/silver/staging/stg_{table_name}.sql`
 
 ```sql
 {{ config(materialized='incremental', unique_key='{primary_key}') }}
@@ -71,7 +68,7 @@ renamed as (
 select * from renamed
 ```
 
-**YAML:** `models/silver/staging/stg_{table_name}.yml` -- primary key always gets `unique` + `not_null`:
+YAML: `models/silver/staging/stg_{table_name}.yml` -- primary key always gets `unique` + `not_null`:
 
 ```yaml
 version: 2
@@ -123,7 +120,7 @@ final as (
 select * from final
 ```
 
-**YAML** -- add `accepted_values` for enums, domain-level `config.tags`:
+YAML -- add `accepted_values` for enums, domain-level `config.tags`:
 
 ```yaml
 version: 2
@@ -173,7 +170,7 @@ final as (
 select * from final
 ```
 
-**YAML** -- `relationships` for FK tests, `dbt_utils.expression_is_true` for range checks:
+YAML -- `relationships` for FK tests, `dbt_utils.expression_is_true` for range checks:
 
 ```yaml
 version: 2

--- a/.agents/skills/add-django-migration/SKILL.md
+++ b/.agents/skills/add-django-migration/SKILL.md
@@ -1,11 +1,8 @@
 ---
-name: django-migration
-description: >
-  Step-by-step workflow for making Django model changes and creating/applying database
-  migrations in the Lotus project. Use this skill whenever the user wants to add a field,
-  create a new model, modify an existing model, add seed data, or run makemigrations/migrate
-  commands. Also trigger for questions about the migration state, rolling back migrations,
-  or anything touching services/django/core/models.py or services/django/core/migrations/.
+name: add-django-migration
+description: Manual skill, do not invoke automatically. Use only when user explicitly runs add-django-migration by name. Step-by-step workflow for making Django model changes and creating/applying database migrations in the Lotus project. Use this skill whenever the user wants to add a field, create a new model, modify an existing model, add seed data, or run makemigrations/migrate commands. Also trigger for questions about the migration state, rolling back migrations, or anything touching services/django/core/models.py or services/django/core/migrations/.
+disable-model-invocation: true
+user-invocable: true
 ---
 
 # Django Migration Workflow
@@ -43,7 +40,7 @@ If you want to check without starting everything:
 docker compose -f docker/docker-compose-local.yaml ps django_admin postgres
 ```
 
-> The `django_admin` service has a volume mount (`services/django:/app`), so edits to local files are immediately reflected in the container — no rebuild needed.
+The `django_admin` service has a volume mount (`services/django:/app`), so edits to local files are immediately reflected in the container — no rebuild needed.
 
 ## Step 3 — Generate the migration file
 
@@ -53,7 +50,7 @@ docker compose -f docker/docker-compose-local.yaml exec django_admin python mana
 
 This creates a new file in `services/django/core/migrations/` following the pattern `000N_description.py`.
 
-After it runs, **read the generated file** and verify:
+After it runs, read the generated file and verify:
 
 - The `dependencies` list chains correctly to the previous migration
 - The operations match what you intended (correct field types, names, constraints)
@@ -115,6 +112,6 @@ Where `000N` is the migration you want to end up at (not the one you're undoing)
 
 ## Key rules
 
-- **Never edit existing migration files.** Once a migration has been applied anywhere, treat it as immutable. If something needs fixing, create a new migration.
+- Never edit existing migration files. Once a migration has been applied anywhere, treat it as immutable. If something needs fixing, create a new migration.
 - Migration files chain via `dependencies` — the order matters and must be kept linear within the `core` app.
 - The `entrypoint.sh` runs `migrate` automatically on container start, so the migration will also apply on the next `make up` / container restart.

--- a/.agents/skills/add-river-job/SKILL.md
+++ b/.agents/skills/add-river-job/SKILL.md
@@ -1,24 +1,26 @@
 ---
-name: river-async-jobs
-description: Step-by-step workflow for adding a new River background job or periodic cron task to the Go backend service.
+name: add-river-job
+description: Manual skill, do not invoke automatically. Use only when user explicitly runs add-river-job by name. Step-by-step workflow for adding a new River background job or periodic cron task to the Go backend service.
+disable-model-invocation: true
+user-invocable: true
 ---
 
 ## Pattern
 
 Every job needs two things, then one wiring step:
 
-**1. New file in `services/backend/internal/jobs/`** — e.g. `send_email.go`:
+1. New file in `services/backend/internal/jobs/` — e.g. `send_email.go`:
 
 - `Args` struct with `Kind() string` and optional `InsertOpts() river.InsertOpts` (set `Queue` and `MaxAttempts`)
 - `Worker` struct embedding `river.WorkerDefaults[Args]` with deps as fields
 - `Work(ctx, job)` method — return an error to trigger retry
 
-**2. Register in `jobs.go` `NewClientWithPeriodicInterval`**:
+2. Register in `jobs.go` `NewClientWithPeriodicInterval`:
 
 - `river.AddWorker(workers, NewMyWorker(...))`
 - For periodic jobs, add a `river.NewPeriodicJob(...)` entry with `&river.PeriodicJobOpts{RunOnStart: true}`
 
-**3. Enqueue from any gRPC handler**:
+3. Enqueue from any gRPC handler:
 
 - `riverClient.Insert(ctx, MyArgs{...}, nil)` — async, returns immediately
 - `riverClient.InsertTx(ctx, tx, MyArgs{...}, nil)` — atomic with a DB write (use for CreateX handlers)

--- a/.claude/skills/add-dagster-asset
+++ b/.claude/skills/add-dagster-asset
@@ -1,0 +1,1 @@
+../../.agents/skills/add-dagster-asset

--- a/.claude/skills/add-dbt-model
+++ b/.claude/skills/add-dbt-model
@@ -1,0 +1,1 @@
+../../.agents/skills/add-dbt-model

--- a/.claude/skills/add-django-migration
+++ b/.claude/skills/add-django-migration
@@ -1,0 +1,1 @@
+../../.agents/skills/add-django-migration

--- a/.claude/skills/add-river-job
+++ b/.claude/skills/add-river-job
@@ -1,0 +1,1 @@
+../../.agents/skills/add-river-job

--- a/.claude/skills/dagster-asset
+++ b/.claude/skills/dagster-asset
@@ -1,1 +1,0 @@
-../../.agents/skills/dagster-asset

--- a/.claude/skills/dbt-model
+++ b/.claude/skills/dbt-model
@@ -1,1 +1,0 @@
-../../.agents/skills/dbt-model

--- a/.claude/skills/django-migration
+++ b/.claude/skills/django-migration
@@ -1,1 +1,0 @@
-../../.agents/skills/django-migration

--- a/.claude/skills/river-async-jobs
+++ b/.claude/skills/river-async-jobs
@@ -1,1 +1,0 @@
-../../.agents/skills/river-async-jobs

--- a/opencode.json
+++ b/opencode.json
@@ -1,7 +1,4 @@
 {
   "$schema": "https://opencode.ai/config.json",
-  "instructions": ["AGENTS.md"],
-  "skills": {
-    "paths": [".agents/skills/add-backend-endpoint"]
-  }
+  "instructions": ["AGENTS.md"]
 }

--- a/services/analyzer/AGENTS.md
+++ b/services/analyzer/AGENTS.md
@@ -4,34 +4,31 @@ FastAPI service for ML/LLM-powered sentiment analysis and topic extraction from 
 
 ## Technology Stack
 
-- **Framework**: FastAPI
-- **Language**: Python 3.13
-- **Database**: PostgreSQL (via SQLAlchemy)
-- **ML Framework**: MLflow for model registry
-- **LLM**: OpenAI API (via instructor library)
-- **Dependency Management**: uv (pyproject.toml)
+- FastAPI
+- MLflow (model registry)
+- OpenAI API
 
 ## Architecture Patterns
 
 ### ML Client Architecture
 
-The service uses a **base class pattern** for MLflow model clients:
+The service uses a base class pattern for MLflow model clients:
 
-1. **`BaseMLflowClient`** (`src/clients/base_mlflow_client.py`)
+1. `BaseMLflowClient` (`src/clients/base_mlflow_client.py`)
    - Handles common MLflow operations
    - Manages model loading, version resolution, metadata tracking
    - Provides `load_model()`, `is_ready()`, and `get_model_info()` methods
 
-2. **Concrete Clients**:
+2. Concrete Clients:
    - `SentimentClient` - Sentiment analysis (inherits from `BaseMLflowClient`)
    - `TopicClient` - Topic extraction (inherits from `BaseMLflowClient`)
    - `OpenAITopicClient` - LLM-based topic extraction (uses OpenAI API)
 
 ### Singleton Pattern
 
-All ML clients use **singleton pattern** via `@lru_cache` in `src/dependencies.py`:
+All ML clients use singleton pattern via `@lru_cache` in `src/dependencies.py`:
 
-- Models are loaded **once** at application startup in the `lifespan` function
+- Models are loaded once at application startup in the `lifespan` function
 - All subsequent requests reuse the same client instance
 - This ensures optimal performance (1000 requests = 1 model load, not 1000)
 
@@ -40,7 +37,7 @@ All ML clients use **singleton pattern** via `@lru_cache` in `src/dependencies.p
 Models are loaded synchronously during application startup:
 
 - Both `TopicClient` and `SentimentClient` models are loaded in `src/main.py` lifespan
-- If model loading fails, the application will **not start** (configurable)
+- If model loading fails, the application will not start (configurable)
 - Models are loaded from MLflow Model Registry using `models:/{model_name}/{version}` format
 - Default version is `"latest"`, but specific versions can be specified
 
@@ -136,7 +133,7 @@ pytest
 
 ### Model Format Requirements
 
-Models **must** be logged to MLflow as `mlflow.pyfunc.PythonModel` instances:
+Models must be logged to MLflow as `mlflow.pyfunc.PythonModel` instances:
 
 - The wrapper class must extend `mlflow.pyfunc.PythonModel`
 - Models are loaded using `mlflow.pyfunc.load_model()` with `models:/` URI format
@@ -156,12 +153,12 @@ Models **must** be logged to MLflow as `mlflow.pyfunc.PythonModel` instances:
 
 Before making changes:
 
-1. **`src/main.py`** - Application entry point, lifespan, model loading
-2. **`src/dependencies.py`** - FastAPI dependencies and singleton clients
-3. **`src/clients/base_mlflow_client.py`** - Base class for ML clients
-4. **`src/config.py`** - Configuration management
-5. **`src/routers/v1/`** - API route handlers
-6. **`tests/conftest.py`** - Test fixtures and setup
+1. `src/main.py` - Application entry point, lifespan, model loading
+2. `src/dependencies.py` - FastAPI dependencies and singleton clients
+3. `src/clients/base_mlflow_client.py` - Base class for ML clients
+4. `src/config.py` - Configuration management
+5. `src/routers/v1/` - API route handlers
+6. `tests/conftest.py` - Test fixtures and setup
 
 ## Common Tasks
 

--- a/services/backend/AGENTS.md
+++ b/services/backend/AGENTS.md
@@ -4,44 +4,41 @@ Go gRPC service with HTTP gateway for core application logic, CRUD operations, a
 
 ## Technology Stack
 
-- **Language**: Go 1.25.4
-- **Framework**: gRPC with grpc-gateway for HTTP
-- **Database**: PostgreSQL
-- **Code Generation**: sqlc (SQL → Go), buf (protobuf → Go), moq (mocks)
-- **Hot Reload**: Air (development only)
-- **Testing**: testify, moq
+- Go
+- gRPC with grpc-gateway
+- PostgreSQL
 
 ## Architecture Patterns
 
 ### Service Structure
 
-The backend runs **two servers** concurrently:
+The backend runs two servers concurrently:
 
-1. **gRPC Server** (`:50051`) - Core gRPC service
-2. **gRPC-Gateway** (`:8080`) - HTTP gateway that translates HTTP → gRPC
+1. gRPC Server (`:50051`) - Core gRPC service
+2. gRPC-Gateway (`:8080`) - HTTP gateway that translates HTTP → gRPC
 
 ### Code Generation
 
-The service uses **code generation** for type safety:
+The service uses code generation for type safety:
 
-- **sqlc** - Generates Go code from SQL queries
+- sqlc - Generates Go code from SQL queries
   - SQL files: `internal/sql/queries/`
   - Generated code: `internal/db/`
   - Config: `sqlc.yaml`
   - Run: `make sqlc-generate` or `cd services/backend && sqlc generate`
 
-- **buf** - Generates gRPC/protobuf code
+- buf - Generates gRPC/protobuf code
   - Proto files: `proto/`
   - Generated code: `internal/pb/proto/`
   - Config: `buf.yaml`, `buf.gen.yaml`
   - Run: `make buf-generate` or `cd services/backend && buf generate`
 
-- **moq** - Generates mock implementations for interfaces
+- moq - Generates mock implementations for interfaces
   - Interfaces: `internal/db/querier.go`, `internal/inject/inject.go`
   - Generated mocks: `internal/mocks/`
   - Run: `make moq-generate` or `./scripts/moq-generate.sh`
 
-**Important**: Always regenerate code after changing SQL queries or proto definitions.
+Important: Always regenerate code after changing SQL queries or proto definitions.
 
 ## Code Organization
 
@@ -88,7 +85,7 @@ internal/
 
 ### gRPC Service Implementation
 
-Services use **context-based dependency injection** via the `inject` package. Dependencies (DB, Logger, HTTPClient, AnalyzerURL) are populated by an interceptor in `main.go` and extracted in handlers:
+Services use context-based dependency injection via the `inject` package. Dependencies (DB, Logger, HTTPClient, AnalyzerURL) are populated by an interceptor in `main.go` and extracted in handlers:
 
 ```go
 type UserServer struct {
@@ -125,7 +122,7 @@ func (s *UserServer) CreateUser(ctx context.Context, req *pb.CreateUserRequest) 
 
 ### Database Access
 
-- Use **sqlc-generated** queries from `internal/db`
+- Use sqlc-generated queries from `internal/db`
 - Never write raw SQL in Go code - use sqlc queries
 - Database access is obtained via `inject.DBFrom(ctx)` (returns `db.Querier`)
 - Use `context.Context` for all database operations
@@ -302,14 +299,14 @@ Raw SQL is still acceptable in tests for unsupported models or specialized datab
 
 Before making changes:
 
-1. **`internal/main.go`** - Entry point, server startup
-2. **`internal/grpc/server.go`** - gRPC server setup and interceptors
-3. **`internal/grpc/journal_service.go`** - Example service implementation
-4. **`internal/db/`** - Generated database code (read-only, regenerated)
-5. **`internal/sql/queries/`** - SQL queries (input for sqlc)
-6. **`proto/`** - Protobuf definitions (input for buf)
-7. **`sqlc.yaml`** - sqlc configuration
-8. **`buf.yaml`** / `buf.gen.yaml` - buf configuration
+1. `internal/main.go` - Entry point, server startup
+2. `internal/grpc/server.go` - gRPC server setup and interceptors
+3. `internal/grpc/journal_service.go` - Example service implementation
+4. `internal/db/` - Generated database code (read-only, regenerated)
+5. `internal/sql/queries/` - SQL queries (input for sqlc)
+6. `proto/` - Protobuf definitions (input for buf)
+7. `sqlc.yaml` - sqlc configuration
+8. `buf.yaml` / `buf.gen.yaml` - buf configuration
 
 ## Common Tasks
 

--- a/services/dagster/AGENTS.md
+++ b/services/dagster/AGENTS.md
@@ -4,21 +4,19 @@ Dagster orchestration service for managing data pipelines, dbt runs, and schedul
 
 ## Technology Stack
 
-- **Framework**: Dagster 1.12.6
-- **Language**: Python 3.13
-- **Database**: PostgreSQL (for Dagster metadata)
-- **Integrations**: dbt, Feast, Redis
-- **Dependency Management**: uv (pyproject.toml)
+- Dagster
+- dbt
+- PostgreSQL
 
 ## Architecture Patterns
 
 ### Service Components
 
-Dagster runs as **three separate services**:
+Dagster runs as three separate services:
 
-1. **dagster_base** - gRPC server for code location
-2. **dagster_webserver** - Web UI for monitoring and running jobs
-3. **dagster_daemon** - Background daemon for scheduled runs
+1. dagster_base - gRPC server for code location
+2. dagster_webserver - Web UI for monitoring and running jobs
+3. dagster_daemon - Background daemon for scheduled runs
 
 All three services use the same Docker image but different entrypoints.
 
@@ -30,7 +28,7 @@ All three services use the same Docker image but different entrypoints.
 
 ### Asset-Based Architecture
 
-Dagster uses **assets** as the primary abstraction:
+Dagster uses assets as the primary abstraction:
 
 - Assets represent data products (tables, files, etc.)
 - Assets have dependencies (upstream assets)
@@ -170,12 +168,12 @@ pytest tests/test_assets.py
 
 Before making changes:
 
-1. **`workspace.yaml`** - Workspace configuration
-2. **`src/dagster_project/__init__.py`** - Code location definition
-3. **`src/dagster_project/assets/`** - Asset definitions
-4. **`src/dagster_project/jobs/`** - Job definitions
-5. **`src/dagster_project/resources/`** - Resource definitions
-6. **`src/dagster_project/schedules/`** - Schedule definitions
+1. `workspace.yaml` - Workspace configuration
+2. `src/dagster_project/__init__.py` - Code location definition
+3. `src/dagster_project/assets/` - Asset definitions
+4. `src/dagster_project/jobs/` - Job definitions
+5. `src/dagster_project/resources/` - Resource definitions
+6. `src/dagster_project/schedules/` - Schedule definitions
 
 ## Common Tasks
 
@@ -278,11 +276,11 @@ Before making changes:
 
 ## Best Practices
 
-1. **Asset Naming**: Use descriptive names that indicate data product
-2. **Dependencies**: Explicitly define asset dependencies
-3. **Resources**: Share resources across assets when possible
-4. **Error Handling**: Handle errors gracefully in assets/ops
-5. **Testing**: Test assets in isolation before integrating
-6. **Documentation**: Document asset purpose and dependencies
-7. **Scheduling**: Use appropriate cron schedules for jobs
-8. **Monitoring**: Monitor run success rates and durations
+1. Asset Naming: Use descriptive names that indicate data product
+2. Dependencies: Explicitly define asset dependencies
+3. Resources: Share resources across assets when possible
+4. Error Handling: Handle errors gracefully in assets/ops
+5. Testing: Test assets in isolation before integrating
+6. Documentation: Document asset purpose and dependencies
+7. Scheduling: Use appropriate cron schedules for jobs
+8. Monitoring: Monitor run success rates and durations

--- a/services/dbt/AGENTS.md
+++ b/services/dbt/AGENTS.md
@@ -4,27 +4,25 @@ dbt (data build tool) for transforming and modeling data in the analytics layer.
 
 ## Technology Stack
 
-- **Tool**: dbt-core 1.10.13+
-- **Adapter**: dbt-postgres 1.9.1+
-- **Language**: SQL (with Jinja templating)
-- **Dependency Management**: uv (pyproject.toml)
+- dbt-core
+- dbt-postgres
 
 ## Architecture Patterns
 
 ### dbt Project Structure
 
-dbt follows a **layered architecture** (staging → silver → gold):
+dbt follows a layered architecture (staging → silver → gold):
 
-1. **Staging** (`models/silver/staging/`) - Raw data transformations
-2. **Silver** (`models/silver/core/`) - Cleaned, validated data models
-3. **Gold** (`models/gold/`) - Final analytics-ready models
+1. Staging (`models/silver/staging/`) - Raw data transformations
+2. Silver (`models/silver/core/`) - Cleaned, validated data models
+3. Gold (`models/gold/`) - Final analytics-ready models
 
 ### Model Organization
 
-- **Sources** (`models/sources/`) - Source table definitions
-- **Staging** - Initial transformations from sources
-- **Silver** - Business logic and core models
-- **Gold** - Final aggregated/analytics models
+- Sources (`models/sources/`) - Source table definitions
+- Staging - Initial transformations from sources
+- Silver - Business logic and core models
+- Gold - Final aggregated/analytics models
 
 ### Naming Conventions
 
@@ -147,9 +145,9 @@ models:
 
 dbt provides built-in testing:
 
-- **Generic tests**: `unique`, `not_null`, `accepted_values`, `relationships`
-- **Singular tests**: Custom SQL tests
-- **Schema tests**: Defined in `.yml` files
+- Generic tests: `unique`, `not_null`, `accepted_values`, `relationships`
+- Singular tests: Custom SQL tests
+- Schema tests: Defined in `.yml` files
 
 ### Running Tests
 
@@ -207,13 +205,13 @@ Main configuration file:
 
 Before making changes:
 
-1. **`dbt_project.yml`** - Project configuration
-2. **`profiles/profiles.yml`** - Database connection configuration
-3. **`models/sources/`** - Source table definitions
-4. **`models/silver/staging/`** - Staging models
-5. **`models/silver/core/`** - Core silver models
-6. **`models/gold/`** - Gold/analytics models
-7. **`macros/`** - Reusable SQL macros
+1. `dbt_project.yml` - Project configuration
+2. `profiles/profiles.yml` - Database connection configuration
+3. `models/sources/` - Source table definitions
+4. `models/silver/staging/` - Staging models
+5. `models/silver/core/` - Core silver models
+6. `models/gold/` - Gold/analytics models
+7. `macros/` - Reusable SQL macros
 
 ## Common Tasks
 
@@ -258,7 +256,7 @@ Before making changes:
 
 - Use consistent indentation (2 or 4 spaces)
 - Use CTEs for complex queries
-- **Do not use table aliases** - Use full table/model names for clarity and consistency
+- Do not use table aliases - Use full table/model names for clarity and consistency
 - Comment complex logic
 - Follow SQL best practices
 
@@ -314,22 +312,22 @@ dbt docs serve
 
 ## Materialization Strategies
 
-- **View**: Lightweight, always up-to-date (staging models)
-- **Table**: Materialized, faster queries (core models)
-- **Incremental**: Only process new data (large tables)
-- **Ephemeral**: CTE, not materialized (intermediate models)
+- View: Lightweight, always up-to-date (staging models)
+- Table: Materialized, faster queries (core models)
+- Incremental: Only process new data (large tables)
+- Ephemeral: CTE, not materialized (intermediate models)
 
 ## Best Practices
 
-1. **Layering**: Follow staging → silver → gold pattern
-2. **Testing**: Test all models, especially core models
-3. **Documentation**: Document all models and columns
-4. **Naming**: Use consistent naming conventions
-5. **Refs**: Always use `{{ ref() }}` for model dependencies
-6. **Sources**: Always use `{{ source() }}` for source tables
-7. **No Table Aliases**: Do not use table aliases (e.g., `j`, `u`) - use full model names for clarity
-8. **Incremental**: Use incremental models for large tables
-9. **Macros**: Create macros for reusable logic
+1. Layering: Follow staging → silver → gold pattern
+2. Testing: Test all models, especially core models
+3. Documentation: Document all models and columns
+4. Naming: Use consistent naming conventions
+5. Refs: Always use `{{ ref() }}` for model dependencies
+6. Sources: Always use `{{ source() }}` for source tables
+7. No Table Aliases: Do not use table aliases (e.g., `j`, `u`) - use full model names for clarity
+8. Incremental: Use incremental models for large tables
+9. Macros: Create macros for reusable logic
 
 ## Pre-commit Hooks
 

--- a/services/django/AGENTS.md
+++ b/services/django/AGENTS.md
@@ -4,11 +4,9 @@ Django application for database migrations, admin interface, and internal data m
 
 ## Technology Stack
 
-- **Framework**: Django 5.0+
-- **Language**: Python 3.13
-- **Database**: PostgreSQL
-- **Admin UI**: django-unfold (modern admin theme)
-- **Dependency Management**: uv (pyproject.toml)
+- Django
+- PostgreSQL
+- django-unfold
 
 ## Architecture Patterns
 
@@ -16,8 +14,8 @@ Django application for database migrations, admin interface, and internal data m
 
 The Django service serves two main purposes:
 
-1. **Database Migrations** - Manages database schema changes
-2. **Admin Interface** - Internal admin UI for managing application data and feature flags
+1. Database Migrations - Manages database schema changes
+2. Admin Interface - Internal admin UI for managing application data and feature flags
 
 ### Model Organization
 
@@ -56,7 +54,7 @@ lotus_admin/
 ### Database Migrations
 
 - Migrations are auto-generated from model changes
-- **Never edit migration files manually** (except for data migrations)
+- Never edit migration files manually (except for data migrations)
 - Create migrations: `python manage.py makemigrations`
 - Apply migrations: `python manage.py migrate`
 
@@ -146,12 +144,12 @@ pytest tests/test_models.py::TestUserModel
 
 Before making changes:
 
-1. **`core/models.py`** - Database models
-2. **`core/admin.py`** - Admin interface configuration
-3. **`core/signals.py`** - Django signals (side effects)
-4. **`core/middleware.py`** - Custom middleware
-5. **`lotus_admin/settings.py`** - Django configuration
-6. **`lotus_admin/urls.py`** - URL routing
+1. `core/models.py` - Database models
+2. `core/admin.py` - Admin interface configuration
+3. `core/signals.py` - Django signals (side effects)
+4. `core/middleware.py` - Custom middleware
+5. `lotus_admin/settings.py` - Django configuration
+6. `lotus_admin/urls.py` - URL routing
 
 ## Common Tasks
 
@@ -209,11 +207,11 @@ python manage.py migrate
 
 ### Migration Workflow
 
-1. **Modify models** in `core/models.py`
-2. **Create migration**: `python manage.py makemigrations`
-3. **Review migration** file in `core/migrations/`
-4. **Test migration**: `python manage.py migrate` (on test DB)
-5. **Commit** both model changes and migration files
+1. Modify models in `core/models.py`
+2. Create migration: `python manage.py makemigrations`
+3. Review migration file in `core/migrations/`
+4. Test migration: `python manage.py migrate` (on test DB)
+5. Commit both model changes and migration files
 
 ### Data Migrations
 
@@ -237,13 +235,13 @@ python manage.py migrate
 
 ### Secret Key
 
-- **Never commit** `DJANGO_SECRET_KEY` to version control
+- Never commit `DJANGO_SECRET_KEY` to version control
 - Use strong, random secret key in production
 - Rotate secret key periodically
 
 ### Debug Mode
 
-- **Never enable** `DJANGO_DEBUG=True` in production
+- Never enable `DJANGO_DEBUG=True` in production
 - Debug mode exposes sensitive information
 - Use environment variable to control debug mode
 

--- a/services/experiments/AGENTS.md
+++ b/services/experiments/AGENTS.md
@@ -4,31 +4,29 @@ ML model training service for sentiment analysis and topic extraction. Models ar
 
 ## Technology Stack
 
-- **Language**: Python 3.13
-- **ML Framework**: scikit-learn, pandas
-- **Model Registry**: MLflow 3.3.1+
-- **Database**: PostgreSQL (for MLflow backend)
-- **Dependency Management**: uv (pyproject.toml)
+- scikit-learn
+- pandas
+- MLflow
 
 ## Architecture Patterns
 
 ### Model Training Workflow
 
-1. **Train Model** - Train ML model using training scripts
-2. **Log to MLflow** - Log model, metrics, and artifacts to MLflow
-3. **Register Model** - Register model in MLflow Model Registry
-4. **Deploy** - Analyzer service loads model from registry
+1. Train Model - Train ML model using training scripts
+2. Log to MLflow - Log model, metrics, and artifacts to MLflow
+3. Register Model - Register model in MLflow Model Registry
+4. Deploy - Analyzer service loads model from registry
 
 ### Model Types
 
 The service trains two main model types:
 
-1. **Sentiment Analyzer** (`src/models/sentiment_analyzer.py`)
+1. Sentiment Analyzer (`src/models/sentiment_analyzer.py`)
    - Model name: `journal_sentiment_analyzer`
    - Purpose: Classify journal sentiment (positive/negative/neutral)
    - Framework: scikit-learn (RoBERTa-based)
 
-2. **Topic Extractor** (`src/models/topic_extractor.py`)
+2. Topic Extractor (`src/models/topic_extractor.py`)
    - Model name: `adaptive_journal_topics`
    - Purpose: Extract topics from journal entries
    - Framework: scikit-learn
@@ -160,10 +158,10 @@ pytest tests/models/test_sentiment_analyzer.py
 
 Before making changes:
 
-1. **`src/models/sentiment_analyzer.py`** - Sentiment model implementation
-2. **`src/models/topic_extractor.py`** - Topic model implementation
-3. **`src/training/train_sentiment_analysis_roberta.py`** - Example training script
-4. **`tests/models/test_sentiment_analyzer.py`** - Model tests
+1. `src/models/sentiment_analyzer.py` - Sentiment model implementation
+2. `src/models/topic_extractor.py` - Topic model implementation
+3. `src/training/train_sentiment_analysis_roberta.py` - Example training script
+4. `tests/models/test_sentiment_analyzer.py` - Model tests
 
 ## Common Tasks
 
@@ -213,21 +211,21 @@ Before making changes:
 
 ### For Analyzer Service Compatibility
 
-Models **must** be logged as `mlflow.pyfunc.PythonModel`:
+Models must be logged as `mlflow.pyfunc.PythonModel`:
 
-1. **Wrapper Class**: Extend `mlflow.pyfunc.PythonModel`
-2. **Predict Method**: Implement `predict(context, model_input)` method
-3. **Input Format**: Accept pandas DataFrame input
-4. **Output Format**: Return list of dictionaries or DataFrame
-5. **Preprocessing**: Handle all preprocessing in `predict()` method
-6. **Postprocessing**: Format predictions consistently
+1. Wrapper Class: Extend `mlflow.pyfunc.PythonModel`
+2. Predict Method: Implement `predict(context, model_input)` method
+3. Input Format: Accept pandas DataFrame input
+4. Output Format: Return list of dictionaries or DataFrame
+5. Preprocessing: Handle all preprocessing in `predict()` method
+6. Postprocessing: Format predictions consistently
 
 ### Model Input/Output
 
-- **Input**: pandas DataFrame with `text` column
-- **Output**: List of dictionaries or DataFrame with predictions
-- **Sentiment**: `{"sentiment": "positive", "confidence": 0.95, ...}`
-- **Topics**: `{"topics": ["topic1", "topic2"], ...}`
+- Input: pandas DataFrame with `text` column
+- Output: List of dictionaries or DataFrame with predictions
+- Sentiment: `{"sentiment": "positive", "confidence": 0.95, ...}`
+- Topics: `{"topics": ["topic1", "topic2"], ...}`
 
 ## Integration with Analyzer Service
 
@@ -253,14 +251,14 @@ Models **must** be logged as `mlflow.pyfunc.PythonModel`:
 
 ## Best Practices
 
-1. **Reproducibility**: Use fixed random seeds
-2. **Versioning**: Always log models with version tracking
-3. **Documentation**: Document model architecture and hyperparameters
-4. **Testing**: Test models before registering
-5. **Metrics**: Log comprehensive metrics (accuracy, precision, recall, etc.)
-6. **Artifacts**: Log training data samples and visualizations
-7. **Experiments**: Use MLflow experiments to organize runs
-8. **Comparison**: Compare model versions in MLflow UI
+1. Reproducibility: Use fixed random seeds
+2. Versioning: Always log models with version tracking
+3. Documentation: Document model architecture and hyperparameters
+4. Testing: Test models before registering
+5. Metrics: Log comprehensive metrics (accuracy, precision, recall, etc.)
+6. Artifacts: Log training data samples and visualizations
+7. Experiments: Use MLflow experiments to organize runs
+8. Comparison: Compare model versions in MLflow UI
 
 ## Pre-commit Hooks
 
@@ -269,7 +267,7 @@ Models **must** be logged as `mlflow.pyfunc.PythonModel`:
 
 ## Deployment
 
-- This service is **not deployed** as a running service
+- This service is not deployed as a running service
 - Training scripts are run manually or via scheduled jobs
 - Models are stored in MLflow Model Registry
 - Analyzer service loads models from registry
@@ -278,10 +276,10 @@ Models **must** be logged as `mlflow.pyfunc.PythonModel`:
 
 ### Model Stages
 
-- **None** - Initial registration
-- **Staging** - Testing phase
-- **Production** - Production-ready models
-- **Archived** - Deprecated models
+- None - Initial registration
+- Staging - Testing phase
+- Production - Production-ready models
+- Archived - Deprecated models
 
 ### Model Promotion
 

--- a/services/frontend/AGENTS.md
+++ b/services/frontend/AGENTS.md
@@ -1,23 +1,18 @@
 # Frontend Service - Agent Guide
 
-Next.js 15 frontend application with React 19, TypeScript, and Tailwind CSS for the journal application UI.
+Next.js frontend application with React, TypeScript, and Tailwind CSS for the journal application UI.
 
 ## Technology Stack
 
-- **Framework**: Next.js 15.3.1
-- **React**: React 19
-- **Language**: TypeScript 5+
-- **Styling**: Tailwind CSS 4.1.4
-- **UI Components**: shadcn/ui (via components.json)
-- **Authentication**: NextAuth.js 5.0 (beta)
-- **Testing**: Jest with React Testing Library, Playwright for E2E
-- **Package Manager**: npm 11.2.0
+- Next.js
+- React
+- TypeScript
 
 ## Architecture Patterns
 
-### App Router (Next.js 15)
+### App Router
 
-Next.js 15 uses the **App Router** architecture:
+Next.js uses the App Router architecture:
 
 - Routes are defined by folder structure in `app/`
 - Server Components by default
@@ -27,15 +22,15 @@ Next.js 15 uses the **App Router** architecture:
 
 ### Component Organization
 
-- **Server Components** - Default, run on server
-- **Client Components** - Marked with `"use client"`, run in browser
-- **Server Actions** - Functions that run on server, called from client
+- Server Components - Default, run on server
+- Client Components - Marked with `"use client"`, run in browser
+- Server Actions - Functions that run on server, called from client
 
 ### Data Fetching
 
-- **Server Components** - Direct data fetching (no hooks)
-- **Client Components** - Use React hooks (`useState`, `useEffect`)
-- **Server Actions** - Mutations via `actions/` directory
+- Server Components - Direct data fetching (no hooks)
+- Client Components - Use React hooks (`useState`, `useEffect`)
+- Server Actions - Mutations via `actions/` directory
 
 ## Code Organization
 
@@ -217,13 +212,13 @@ describe("JournalCard", () => {
 
 Before making changes:
 
-1. **`app/layout.tsx`** - Root layout and providers
-2. **`app/page.tsx`** - Home page
-3. **`middleware.ts`** - Next.js middleware (auth, etc.)
-4. **`components/ui/`** - shadcn/ui components
-5. **`lib/server/`** - Server-side data fetching
-6. **`actions/`** - Server Actions for mutations
-7. **`types/`** - TypeScript type definitions
+1. `app/layout.tsx` - Root layout and providers
+2. `app/page.tsx` - Home page
+3. `middleware.ts` - Next.js middleware (auth, etc.)
+4. `components/ui/` - shadcn/ui components
+5. `lib/server/` - Server-side data fetching
+6. `actions/` - Server Actions for mutations
+7. `types/` - TypeScript type definitions
 
 ## Common Tasks
 
@@ -374,11 +369,11 @@ Before making changes:
 
 ## Best Practices
 
-1. **Server Components First**: Use Server Components by default
-2. **Type Safety**: Use TypeScript for all code
-3. **Component Composition**: Build complex UIs from simple components
-4. **Error Handling**: Handle errors gracefully
-5. **Accessibility**: Follow WCAG guidelines
-6. **Performance**: Optimize images and code splitting
-7. **Testing**: Write tests for critical components
-8. **Documentation**: Document complex logic and components
+1. Server Components First: Use Server Components by default
+2. Type Safety: Use TypeScript for all code
+3. Component Composition: Build complex UIs from simple components
+4. Error Handling: Handle errors gracefully
+5. Accessibility: Follow WCAG guidelines
+6. Performance: Optimize images and code splitting
+7. Testing: Write tests for critical components
+8. Documentation: Document complex logic and components


### PR DESCRIPTION
## Description

Standardize the repo's agent-facing files: rely on OpenCode's native `.agents/skills` discovery, give skills clear verb-based names, mark them manual-only, and trim markup/versions from the instruction files to reduce tokens.

### Updated

- Renamed skills to `<verb>-<service>-<xyz>` (e.g. `dbt-model` → `add-dbt-model`), updating `name:` frontmatter and `.claude/skills` symlinks
- Marked all skills manual-only via `disable-model-invocation`/`user-invocable` plus a "do not invoke automatically" description prefix
- Stripped bold/italic/blockquote markup and pinned package versions from every `AGENTS.md` and `SKILL.md`; trimmed each Technology Stack to 2-3 high-level packages

### Deleted

- Removed the non-standard `skills.paths` block from `opencode.json` (`.agents/skills` is auto-discovered)